### PR TITLE
Initialize monorepo structure with tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm install
+      - run: npm run lint
+      - run: npm test
+      - run: npm run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+packages/*/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+COPY packages ./packages
+RUN npm install
+RUN npm run typecheck
+CMD ["node", "packages/backend/dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Codexia Monorepo
+
+This repository hosts multiple packages:
+
+- `packages/contracts` – shared TypeScript contracts.
+- `packages/backend` – backend service.
+- `packages/frontend` – console web app.
+- `packages/extension` – sidebar extension.
+
+Additional directories:
+
+- `infra` – infrastructure configuration (e.g. docker-compose).
+- `scripts` – reusable scripts.
+
+## Tooling
+
+Common tooling is configured at the root:
+
+- **Lint**: `npm run lint`
+- **Test**: `npm test`
+- **Typecheck**: `npm run typecheck`
+- **Docker**: `docker build -t codexia .`
+
+Continuous integration runs these commands via GitHub Actions.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,5 @@
+module.exports = [
+  {
+    ignores: ['node_modules', 'dist']
+  }
+];

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  backend:
+    build: ..
+    command: node packages/backend/dist/index.js
+    volumes:
+      - ..:/app
+    working_dir: /app
+    ports:
+      - "3000:3000"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/packages'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "codexia",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "scripts": {
+    "lint": "eslint .",
+    "test": "jest",
+    "typecheck": "tsc -b"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.3",
+    "@typescript-eslint/eslint-plugin": "^6.6.0",
+    "@typescript-eslint/parser": "^6.6.0",
+    "eslint": "^8.48.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@codexia/backend",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@codexia/contracts": "1.0.0"
+  }
+}

--- a/packages/backend/src/index.test.ts
+++ b/packages/backend/src/index.test.ts
@@ -1,0 +1,5 @@
+import { start } from './index';
+
+test('start returns backend version', () => {
+  expect(start()).toBe('Backend 1.0');
+});

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,0 +1,5 @@
+import { version } from '@codexia/contracts';
+
+export function start(): string {
+  return `Backend ${version()}`;
+}

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../contracts"
+    }
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@codexia/contracts",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT"
+}

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -1,0 +1,5 @@
+import { version } from './index';
+
+test('version is 1.0', () => {
+  expect(version()).toBe('1.0');
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,7 @@
+export interface Contract {
+  id: string;
+}
+
+export function version(): string {
+  return '1.0';
+}

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@codexia/extension",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@codexia/contracts": "1.0.0"
+  }
+}

--- a/packages/extension/src/index.test.ts
+++ b/packages/extension/src/index.test.ts
@@ -1,0 +1,5 @@
+import { show } from './index';
+
+test('show returns extension version', () => {
+  expect(show()).toBe('Extension 1.0');
+});

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -1,0 +1,5 @@
+import { version } from '@codexia/contracts';
+
+export function show(): string {
+  return `Extension ${version()}`;
+}

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../contracts"
+    }
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@codexia/frontend",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@codexia/contracts": "1.0.0"
+  }
+}

--- a/packages/frontend/src/index.test.ts
+++ b/packages/frontend/src/index.test.ts
@@ -1,0 +1,5 @@
+import { render } from './index';
+
+test('render returns frontend version', () => {
+  expect(render()).toBe('Frontend 1.0');
+});

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -1,0 +1,5 @@
+import { version } from '@codexia/contracts';
+
+export function render(): string {
+  return `Frontend ${version()}`;
+}

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../contracts"
+    }
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}

--- a/scripts/hello.js
+++ b/scripts/hello.js
@@ -1,0 +1,1 @@
+console.log('Hello from script');

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@codexia/contracts": [
+        "packages/contracts/src"
+      ]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./packages/contracts"},
+    {"path": "./packages/backend"},
+    {"path": "./packages/frontend"},
+    {"path": "./packages/extension"}
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold backend, frontend, extension and shared contracts packages
- add TypeScript base config, linting, testing and build scripts
- include Dockerfile, docker-compose and CI workflow

## Testing
- `npm run lint`
- `npm test` *(fails: jest: not found)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bbd203f9508322b8b18a8a4d727401