### PR TITLE
feat(backend): add fastapi skeleton with stubbed routers

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,4 +1,5 @@
 MODEL_PROVIDER=local
+EMBEDDING_MODEL=all-MiniLM-L6-v2
 VECTOR_PATH=./var/vector
 AUDIT_PATH=./var/audit
 LOG_LEVEL=INFO

--- a/packages/backend/app.py
+++ b/packages/backend/app.py
@@ -1,19 +1,50 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_client import CollectorRegistry, CONTENT_TYPE_LATEST, Counter, generate_latest
+from starlette.responses import Response
+from fastapi.responses import ORJSONResponse
+from .routers import health_router, assess_router, plan_router, act_router, brief_router
+from .core.config import Settings
+from .core.security import SecurityMiddleware
+from .core.logging import configure as configure_logging
+import os
 
-from .routers import health, assess, plan, act, brief
+_registry = CollectorRegistry()
+REQUESTS = Counter("codexia_requests_total", "HTTP requests", ["path"], registry=_registry)
 
-app = FastAPI()
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
 
-app.include_router(health.router)
-app.include_router(assess.router, prefix="/v1")
-app.include_router(plan.router, prefix="/v1")
-app.include_router(act.router, prefix="/v1")
-app.include_router(brief.router, prefix="/v1")
+def get_app() -> FastAPI:
+    configure_logging()
+    app = FastAPI(title="Codexia API", version=os.getenv("APP_VERSION","0.1.0"), default_response_class=ORJSONResponse)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173","http://127.0.0.1:5173"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.add_middleware(SecurityMiddleware)
+
+    settings = Settings()  # ensures paths exist
+
+    @app.middleware("http")
+    async def metrics_mw(request, call_next):
+        resp = await call_next(request)
+        try: REQUESTS.labels(path=request.url.path).inc()
+        except Exception: pass
+        return resp
+
+    app.include_router(health_router)
+    app.include_router(assess_router)
+    app.include_router(plan_router)
+    app.include_router(act_router)
+    app.include_router(brief_router)
+
+    @app.get("/metrics")
+    def metrics():
+        return Response(generate_latest(_registry), media_type=CONTENT_TYPE_LATEST)
+
+    return app
+
+app = get_app()

--- a/packages/backend/core/audit.py
+++ b/packages/backend/core/audit.py
@@ -1,2 +1,19 @@
-def record_event(event: str) -> None:
-    pass
+import json
+import os
+from datetime import datetime
+from hashlib import sha256
+from .config import Settings
+
+
+def audit_write(kind: str, payload: dict) -> None:
+    settings = Settings()
+    ts = datetime.utcnow().strftime("%Y-%m-%d")
+    path = os.path.join(settings.AUDIT_PATH, f"{ts}.jsonl")
+    record = {
+        "ts": datetime.utcnow().isoformat() + "Z",
+        "kind": kind,
+        "sha256": sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest(),
+        "payload": payload,
+    }
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")

--- a/packages/backend/core/config.py
+++ b/packages/backend/core/config.py
@@ -1,13 +1,17 @@
-from __future__ import annotations
-
-from pydantic_settings import BaseSettings
+import os
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    model_provider: str = "local"
-    vector_path: str = "./var/vector"
-    audit_path: str = "./var/audit"
-    log_level: str = "INFO"
+    model_config = SettingsConfigDict(env_prefix="", env_file=".env")
 
+    MODEL_PROVIDER: str = "local"
+    EMBEDDING_MODEL: str = "all-MiniLM-L6-v2"
+    VECTOR_PATH: str = "./var/vector"
+    AUDIT_PATH: str = "./var/audit"
+    LOG_LEVEL: str = "INFO"
 
-settings = Settings()
+    def model_post_init(self, __context):
+        os.makedirs(self.VECTOR_PATH, exist_ok=True)
+        os.makedirs(self.AUDIT_PATH, exist_ok=True)
+

--- a/packages/backend/core/logging.py
+++ b/packages/backend/core/logging.py
@@ -1,6 +1,36 @@
 import logging
-from .config import settings
+import re
+from datetime import datetime
+from pythonjsonlogger import jsonlogger
+from .config import Settings
+
+EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+NPI_RE = re.compile(r"\b\d{10}\b")
+
+
+def redact(text: str) -> str:
+    text = EMAIL_RE.sub("[redacted-email]", text)
+    text = NPI_RE.sub("[redacted-npi]", text)
+    return text
+
+
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        log_record.setdefault("ts", datetime.utcnow().isoformat() + "Z")
+        log_record.setdefault("level", record.levelname)
+        if "message" in log_record:
+            log_record["msg"] = redact(log_record.pop("message"))
+        for field in ["path", "method", "status", "dur_ms", "req_id"]:
+            log_record.setdefault(field, None)
 
 
 def configure() -> None:
-    logging.basicConfig(level=getattr(logging, settings.log_level, "INFO"))
+    settings = Settings()
+    handler = logging.StreamHandler()
+    formatter = CustomJsonFormatter()
+    handler.setFormatter(formatter)
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(getattr(logging, settings.LOG_LEVEL, "INFO"))

--- a/packages/backend/core/security.py
+++ b/packages/backend/core/security.py
@@ -1,2 +1,25 @@
-def get_current_user() -> str:
-    return "anonymous"
+import time
+from uuid import uuid4
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class SecurityMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, max_body_size: int = int(1.5 * 1024 * 1024)):
+        super().__init__(app)
+        self.max_body_size = max_body_size
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = request.headers.get("X-Request-Id") or str(uuid4())
+        start = time.time()
+        body = await request.body()
+        if len(body) > self.max_body_size:
+            return Response(status_code=413)
+        request._body = body  # allow downstream to read again
+        request.state.request_id = request_id
+        response = await call_next(request)
+        duration = int((time.time() - start) * 1000)
+        response.headers.setdefault("X-Request-Id", request_id)
+        response.headers.setdefault("X-Response-Time", str(duration))
+        return response

--- a/packages/backend/deps.py
+++ b/packages/backend/deps.py
@@ -1,0 +1,7 @@
+from functools import lru_cache
+from .core.config import Settings
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.112.*
+uvicorn[standard]==0.30.*
+pydantic==2.8.*
+pydantic-settings==2.3.*
+prometheus-client==0.20.*
+orjson==3.10.*
+python-json-logger==2.0.*
+pytest==8.*
+httpx==0.27.*

--- a/packages/backend/routers/__init__.py
+++ b/packages/backend/routers/__init__.py
@@ -1,3 +1,13 @@
-from . import health, assess, plan, act, brief
+from .health import router as health_router
+from .assess import router as assess_router
+from .plan import router as plan_router
+from .act import router as act_router
+from .brief import router as brief_router
 
-__all__ = ["health", "assess", "plan", "act", "brief"]
+__all__ = [
+    "health_router",
+    "assess_router",
+    "plan_router",
+    "act_router",
+    "brief_router",
+]

--- a/packages/backend/routers/act.py
+++ b/packages/backend/routers/act.py
@@ -1,10 +1,25 @@
 from fastapi import APIRouter
+from pydantic import BaseModel
+from ..core.audit import audit_write
+from ..schemas import Claim, PlanResult, ActResult
 
-from codexia_contracts.contracts import PlanResult, ActResult
+router = APIRouter(prefix="/v1", tags=["rcm"])
 
-router = APIRouter()
+
+class ActRequest(BaseModel):
+    claim: Claim
+    plan: PlanResult
 
 
 @router.post("/act", response_model=ActResult)
-def act(plan: PlanResult) -> ActResult:
-    return ActResult(claim_id=plan.claim_id, actions=[])
+def act(body: ActRequest) -> ActResult:
+    # For demo: if first plan is recoding, echo corrected JSON; else return letter md
+    if body.plan.plans and body.plan.plans[0].type == "recoding":
+        corrected = body.claim.model_dump() if hasattr(body.claim, "model_dump") else body.claim.__dict__
+        # apply the modifier (demo-safe)
+        corrected["lines"][0]["modifiers"] = ["59"]
+        artifact = {"artifactType":"corrected_claim","payload":corrected}
+    else:
+        artifact = {"artifactType":"appeal_letter","payload":{"markdown":"# Appeal\n...","cites":["CMS-NCD-456 §2"]}}
+    audit_write(kind="act", payload=artifact)
+    return ActResult(**artifact)

--- a/packages/backend/routers/assess.py
+++ b/packages/backend/routers/assess.py
@@ -1,10 +1,14 @@
 from fastapi import APIRouter
+from ..schemas import Claim, AssessmentResult
 
-from codexia_contracts.contracts import Claim, AssessmentResult
-
-router = APIRouter()
+router = APIRouter(prefix="/v1", tags=["rcm"])
 
 
 @router.post("/assess", response_model=AssessmentResult)
 def assess(claim: Claim) -> AssessmentResult:
-    return AssessmentResult(claim_id=claim.claim_id, risk=0.5, drivers=[], evidence=[])
+    # deterministic stub
+    return AssessmentResult(
+        risk=0.72,
+        drivers=[{"line":0,"issue":"modifier_missing","why":"97012 + 97110 same DOS"}],
+        evidence=[{"source":"UHC-LCD-123.md","clauseId":"UHC-LCD-123 §3b","passage":"...","effective":{"from":"2024-01-01"}}],
+    )

--- a/packages/backend/routers/brief.py
+++ b/packages/backend/routers/brief.py
@@ -1,10 +1,15 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
+from ..schemas import BriefResult
 
-from codexia_contracts.contracts import ActResult, BriefResult
-
-router = APIRouter()
+router = APIRouter(prefix="/v1", tags=["rcm"])
 
 
-@router.post("/brief", response_model=BriefResult)
-def brief(act: ActResult) -> BriefResult:
-    return BriefResult(claim_id=act.claim_id, summary="")
+@router.get("/brief", response_model=BriefResult)
+def brief(user_id: str = Query(...), date: str = Query(...)) -> BriefResult:
+    return BriefResult(
+        highlights=["UHC-LCD-123 updated on 2025-08-01"],
+        queue=[
+            {"claimId":"CLM-1001","score":0.91,"expDeltaUsd":126.0,"why":["modifier"],"etaMin":2},
+            {"claimId":"CLM-1002","score":0.86,"expDeltaUsd":410.0,"why":["NCD"],"etaMin":6,"deadline":"2025-09-12"},
+        ],
+    )

--- a/packages/backend/routers/health.py
+++ b/packages/backend/routers/health.py
@@ -1,13 +1,9 @@
 from fastapi import APIRouter
+import os
 
-router = APIRouter()
+router = APIRouter(tags=["ops"])
 
 
 @router.get("/healthz")
-def healthz() -> dict[str, str]:
-    return {"status": "ok"}
-
-
-@router.get("/metrics")
-def metrics() -> str:
-    return "# metrics\n"
+def healthz():
+    return {"status": "ok", "gitSha": os.getenv("GIT_SHA", "unknown")}

--- a/packages/backend/routers/plan.py
+++ b/packages/backend/routers/plan.py
@@ -1,10 +1,18 @@
 from fastapi import APIRouter
+from pydantic import BaseModel
+from ..schemas import Claim, AssessmentResult, PlanResult
 
-from codexia_contracts.contracts import Claim, PlanResult, RecodingPlan
+router = APIRouter(prefix="/v1", tags=["rcm"])
 
-router = APIRouter()
+
+class PlanRequest(BaseModel):
+    claim: Claim
+    assessment: AssessmentResult
 
 
 @router.post("/plan", response_model=PlanResult)
-def plan(claim: Claim) -> PlanResult:
-    return RecodingPlan(claim_id=claim.claim_id, codes=[])
+def plan(body: PlanRequest) -> PlanResult:
+    return PlanResult(plans=[
+        {"type":"recoding","actions":[{"line":0,"addModifier":"59","cite":"UHC-LCD-123 §3b"}],"rationale":"Distinct procedural service"},
+        {"type":"appeal","actions":[{"level":"L1","reason":"medical_necessity","cites":["CMS-NCD-456 §2"]}],"rationale":"Policy ambiguity"}
+    ])

--- a/packages/backend/schemas/__init__.py
+++ b/packages/backend/schemas/__init__.py
@@ -1,0 +1,3 @@
+from .fallback_contracts import Claim, AssessmentResult, PlanResult, ActResult, BriefResult
+
+__all__ = ["Claim","AssessmentResult","PlanResult","ActResult","BriefResult"]

--- a/packages/backend/schemas/fallback_contracts.py
+++ b/packages/backend/schemas/fallback_contracts.py
@@ -1,0 +1,98 @@
+try:
+    # canonical (when packages/contracts-py lands)
+    from codexia_contracts.contracts import (
+        Claim, AssessmentResult, PlanResult, ActResult, BriefResult
+    )
+except Exception:
+    # fallback stubs (strict enough for tests)
+    from pydantic import BaseModel, Field, ConfigDict
+    from typing import List, Optional, Literal
+
+    class Evidence(BaseModel):
+        source: str
+        clauseId: str
+        passage: str
+        effective: dict
+
+    class Driver(BaseModel):
+        line: int
+        issue: Literal["modifier_missing","dx_incompatibility","ncd_exclusion","sos_restriction","doc_missing","other"]
+        why: str
+
+    class ClaimLine(BaseModel):
+        cpt: str
+        dx: List[str]
+        modifiers: List[str] = Field(default_factory=list)
+        units: int
+        charge: float
+
+    class Payer(BaseModel):
+        name: str
+        planId: Optional[str] = None
+        state: Optional[str] = None
+
+    class Patient(BaseModel):
+        dob: str
+        age: int
+        sex: str
+
+    class Provider(BaseModel):
+        npi: str
+        siteOfService: Optional[str] = None
+
+    class Claim(BaseModel):
+        model_config = ConfigDict(extra="ignore")
+        claimId: str
+        payer: Payer
+        patient: Patient
+        provider: Provider
+        lines: List[ClaimLine]
+        attachments: Optional[List[dict]] = None
+        history: Optional[List[dict]] = None
+        notes: Optional[List[str]] = None
+
+    class AssessmentResult(BaseModel):
+        model_config = ConfigDict(extra="ignore")
+        risk: float = Field(ge=0.0, le=1.0)
+        drivers: List[Driver] = Field(default_factory=list)
+        evidence: List[Evidence] = Field(default_factory=list)
+
+    class RecodingAction(BaseModel):
+        line: int
+        addModifier: Optional[str] = None
+        replaceDx: Optional[dict] = None
+        cite: Optional[str] = None
+
+    class RecodingPlan(BaseModel):
+        type: Literal["recoding"]
+        actions: List[RecodingAction]
+        rationale: str
+
+    class AppealAction(BaseModel):
+        level: Literal["L1","L2"]
+        reason: str
+        cites: List[str] = Field(default_factory=list)
+
+    class AppealPlan(BaseModel):
+        type: Literal["appeal"]
+        actions: List[AppealAction]
+        rationale: str
+
+    class PlanResult(BaseModel):
+        plans: List[RecodingPlan | AppealPlan] = Field(default_factory=list)
+
+    class ActResult(BaseModel):
+        artifactType: Literal["corrected_claim","appeal_letter"]
+        payload: dict
+
+    class BriefItem(BaseModel):
+        claimId: str
+        score: float
+        expDeltaUsd: float
+        why: List[str]
+        etaMin: int
+        deadline: Optional[str] = None
+
+    class BriefResult(BaseModel):
+        highlights: List[str] = Field(default_factory=list)
+        queue: List[BriefItem] = Field(default_factory=list)

--- a/packages/backend/tests/test_health.py
+++ b/packages/backend/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from packages.backend.app import app
+
+
+def test_healthz():
+    c = TestClient(app)
+    r = c.get("/healthz")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"

--- a/packages/backend/tests/test_routes_contracts.py
+++ b/packages/backend/tests/test_routes_contracts.py
@@ -1,0 +1,38 @@
+from fastapi.testclient import TestClient
+from packages.backend.app import app
+
+CASE_MOD59 = {
+  "claimId": "CLM-1001",
+  "payer": {"name": "UnitedHealthcare", "planId": "UHC-GOLD-CA", "state": "CA"},
+  "patient": {"dob": "1962-05-14", "age": 63, "sex": "F"},
+  "provider": {"npi": "1093817465", "siteOfService": "11"},
+  "lines": [
+    {"cpt": "97012", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 180.00},
+    {"cpt": "97110", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 190.00}
+  ],
+  "attachments": [{"type":"progress_note", "id":"doc_123"}],
+  "history": [{"ts":"2025-09-05T10:00:00Z","event":"created"}],
+  "notes": ["Therapeutic exercise same session; distinct procedural service not indicated in line 1."]
+}
+
+
+def test_assess_stub():
+    c = TestClient(app)
+    r = c.post("/v1/assess", json=CASE_MOD59)
+    assert r.status_code == 200
+    data = r.json()
+    assert 0.0 <= data["risk"] <= 1.0
+    assert isinstance(data["drivers"], list)
+    assert isinstance(data["evidence"], list)
+
+
+def test_plan_and_act_stub():
+    c = TestClient(app)
+    assess = c.post("/v1/assess", json=CASE_MOD59).json()
+    plan = c.post("/v1/plan", json={"claim": CASE_MOD59, "assessment": assess}).json()
+    assert "plans" in plan and len(plan["plans"]) >= 1
+    act = c.post("/v1/act", json={"claim": CASE_MOD59, "plan": plan})
+    assert act.status_code == 200
+    payload = act.json()["payload"]
+    assert "lines" in payload or "markdown" in payload
+


### PR DESCRIPTION
## Summary
- add FastAPI app factory with metrics, CORS, and versioned rcm routers
- stub logging, security, and audit utilities
- provide fallback Pydantic contracts and basic route tests

## Testing
- `pip install -r packages/backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.112.*)*
- `cd packages/backend && pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68bbda990df483228ddf6cc92cab6b3b