### PR TITLE
Add deterministic RAG layer with FAISS and local policy corpus

### DIFF
--- a/packages/backend/core/config.py
+++ b/packages/backend/core/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     VECTOR_PATH: str = "./var/vector"
     AUDIT_PATH: str = "./var/audit"
     LOG_LEVEL: str = "INFO"
+    RAG_TOPK_DEFAULT: int = 5
 
     def model_post_init(self, __context):
         os.makedirs(self.VECTOR_PATH, exist_ok=True)

--- a/packages/backend/data/policies/Aetna-PL-987.md
+++ b/packages/backend/data/policies/Aetna-PL-987.md
@@ -1,0 +1,4 @@
+# Aetna-PL-987 — Musculoskeletal Coding
+- clause_id: Aetna-PL-987 §1
+- effective: 2024-03-01 →
+Text: CPT 97110 with diagnosis M25.50 (pain in unspecified joint) is not sufficient for payment without additional site-specific diagnosis (e.g., M25.512). Modifier 59 may be required when paired with traction CPT 97012 on the same DOS.

--- a/packages/backend/data/policies/Anthem-BUL-09.md
+++ b/packages/backend/data/policies/Anthem-BUL-09.md
@@ -1,0 +1,4 @@
+# Anthem-BUL-09 — Documentation Requirements
+- clause_id: Anthem-BUL-09 §3
+- effective: 2024-04-15 →
+Text: Progress notes must include time, technique, and body region for therapeutic services. Missing elements may trigger denial or recoupment.

--- a/packages/backend/data/policies/BCBS-P123.md
+++ b/packages/backend/data/policies/BCBS-P123.md
@@ -1,0 +1,4 @@
+# BCBS-P123 — Imaging and Site-of-Service
+- clause_id: BCBS-P123 §7
+- effective: 2024-02-01 →
+Text: Certain imaging services are restricted in ambulatory surgical centers; claims must include appropriate POS and documentation. Physician office (POS 11) claims require documented clinical rationale.

--- a/packages/backend/data/policies/CMS-NCD-456.md
+++ b/packages/backend/data/policies/CMS-NCD-456.md
@@ -1,0 +1,8 @@
+# CMS-NCD-456 — Laboratory Testing Policy
+- clause_id: CMS-NCD-456 §2
+- effective: 2023-06-01 →
+Text: Test XYZ is considered medically necessary when diagnosis codes from M25.5x or M54.xx are present and documentation indicates functional impairment. Claims lacking these diagnoses are non-covered.
+
+- clause_id: CMS-NCD-456 §5
+- effective: 2023-06-01 → 2025-08-31
+Text: Site-of-service restrictions apply for outpatient facilities. Physician office claims (POS 11) are allowed when documentation supports medical necessity. Prior authorization is not required under Medicare.

--- a/packages/backend/data/policies/Cigna-MED-77.md
+++ b/packages/backend/data/policies/Cigna-MED-77.md
@@ -1,0 +1,4 @@
+# Cigna-MED-77 — Modifier Policy
+- clause_id: Cigna-MED-77 §2
+- effective: 2023-12-01 →
+Text: Modifier 59 is appropriate only when procedures are independent or at different anatomical sites. Overuse without documentation may result in denial.

--- a/packages/backend/data/policies/Kaiser-ACL-22.md
+++ b/packages/backend/data/policies/Kaiser-ACL-22.md
@@ -1,0 +1,4 @@
+# Kaiser-ACL-22 — Physical Therapy Bundling
+- clause_id: Kaiser-ACL-22 §1
+- effective: 2024-01-01 →
+Text: Bundling edits may apply to 97012 and 97110 submitted together; distinct procedural services must be clearly documented or indicated with modifier 59.

--- a/packages/backend/data/policies/Medicare-AB-2024-05.md
+++ b/packages/backend/data/policies/Medicare-AB-2024-05.md
@@ -1,0 +1,4 @@
+# Medicare-AB-2024-05 — General Coding Guidance
+- clause_id: Medicare-AB-2024-05 §4
+- effective: 2024-05-01 →
+Text: ICD-10 codes must reflect the most specific diagnosis available; unspecified codes (NOS) should be replaced with site-specific variants when supported by documentation.

--- a/packages/backend/data/policies/UHC-LCD-123.md
+++ b/packages/backend/data/policies/UHC-LCD-123.md
@@ -1,0 +1,8 @@
+# UHC-LCD-123 — Musculoskeletal Rehab
+- clause_id: UHC-LCD-123 §3a
+- effective: 2024-01-01 →
+Text: CPT 97110 (therapeutic exercise) is payable when medically necessary and supported by documentation of therapeutic goals and time. Separate payment may not be allowed when reported with traction CPT 97012 without adequate documentation.
+
+- clause_id: UHC-LCD-123 §3b
+- effective: 2024-01-01 →
+Text: When CPT 97012 (mechanical traction) is billed on the same date of service as 97110 (therapeutic exercise), payment may require modifier 59 to indicate a distinct procedural service unless documentation clearly supports separate time and anatomical location.

--- a/packages/backend/rag/__init__.py
+++ b/packages/backend/rag/__init__.py
@@ -1,0 +1,16 @@
+from .indexer import build_index, load_index
+from .retrieve import semantic_search, query_policy_for_claim_context, top_citations_for_issue
+from .normalize import normalize_text, extract_clauses
+from .types import Passage, Retrieval
+
+__all__ = [
+    "build_index",
+    "load_index",
+    "semantic_search",
+    "query_policy_for_claim_context",
+    "top_citations_for_issue",
+    "normalize_text",
+    "extract_clauses",
+    "Passage",
+    "Retrieval",
+]

--- a/packages/backend/rag/indexer.py
+++ b/packages/backend/rag/indexer.py
@@ -1,0 +1,78 @@
+import os
+import json
+import glob
+import random
+from typing import Tuple
+
+import numpy as np
+import faiss
+from sentence_transformers import SentenceTransformer
+
+from .normalize import extract_clauses
+from .types import Passage
+
+MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _gather_passages(policies_dir: str) -> list[Passage]:
+    passages: list[Passage] = []
+    for path in sorted(glob.glob(os.path.join(policies_dir, "*.md"))):
+        with open(path, "r", encoding="utf-8") as f:
+            md = f.read()
+        passages.extend(extract_clauses(md, os.path.basename(path)))
+    return passages
+
+
+def build_index(policies_dir: str, vector_dir: str, rebuild: bool = False):
+    os.makedirs(vector_dir, exist_ok=True)
+    index_path = os.path.join(vector_dir, "index.faiss")
+    meta_path = os.path.join(vector_dir, "meta.json")
+
+    if (
+        not rebuild
+        and os.path.exists(index_path)
+        and os.path.exists(meta_path)
+    ):
+        latest_src = max(
+            os.path.getmtime(p)
+            for p in glob.glob(os.path.join(policies_dir, "*.md"))
+        )
+        if os.path.getmtime(meta_path) >= latest_src:
+            return load_index(vector_dir)
+
+    random.seed(13)
+    np.random.seed(13)
+    try:
+        import torch
+        torch.manual_seed(13)
+    except Exception:
+        pass
+
+    passages = _gather_passages(policies_dir)
+    texts = [p["text"] for p in passages]
+
+    model = SentenceTransformer(MODEL_NAME)
+    embeddings = model.encode(texts, show_progress_bar=False, normalize_embeddings=True)
+    embeddings = embeddings.astype("float32")
+    dim = embeddings.shape[1]
+
+    index = faiss.IndexFlatL2(dim)
+    index.add(embeddings)
+    faiss.write_index(index, index_path)
+
+    meta = {"vector_dim": dim, "model": MODEL_NAME, "passages": passages}
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(meta, f, ensure_ascii=False, indent=2)
+
+    return index, meta
+
+
+def load_index(vector_dir: str):
+    index_path = os.path.join(vector_dir, "index.faiss")
+    meta_path = os.path.join(vector_dir, "meta.json")
+    if not (os.path.exists(index_path) and os.path.exists(meta_path)):
+        raise FileNotFoundError("Vector index not found; build it first")
+    index = faiss.read_index(index_path)
+    with open(meta_path, "r", encoding="utf-8") as f:
+        meta = json.load(f)
+    return index, meta

--- a/packages/backend/rag/normalize.py
+++ b/packages/backend/rag/normalize.py
@@ -1,0 +1,55 @@
+import re
+from typing import List
+from .types import Passage
+
+ALLOWED_CHARS = re.compile(r"[^a-z0-9\s\-_/.:()§]")
+SPACE_RE = re.compile(r"\s+")
+
+
+def normalize_text(s: str) -> str:
+    s = s.lower()
+    s = ALLOWED_CHARS.sub(" ", s)
+    s = SPACE_RE.sub(" ", s)
+    return s.strip()
+
+
+def extract_clauses(md: str, source: str) -> List[Passage]:
+    lines = md.splitlines()
+    passages: List[Passage] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if line.startswith("- clause_id:"):
+            clause_id = line.split(":", 1)[1].strip()
+            i += 1
+            if i >= len(lines):
+                break
+            eff_line = lines[i].strip()
+            m = re.match(r"- effective:\s*(\d{4}-\d{2}-\d{2})\s*→\s*(\d{4}-\d{2}-\d{2})?", eff_line)
+            if not m:
+                i += 1
+                continue
+            effective_from = m.group(1)
+            effective_to = m.group(2) or None
+            i += 1
+            text_lines = []
+            if i < len(lines) and lines[i].strip().startswith("Text:"):
+                text_lines.append(lines[i].split("Text:", 1)[1].strip())
+                i += 1
+                while i < len(lines) and not lines[i].strip().startswith("- clause_id:") and lines[i].strip() != "":
+                    text_lines.append(lines[i].strip())
+                    i += 1
+            text = " ".join(text_lines).strip()
+            passage_text = f"{clause_id} ({effective_from}→{effective_to or ''}) {text}".strip()
+            passages.append(
+                Passage(
+                    text=passage_text,
+                    source=source,
+                    clause_id=clause_id,
+                    effective_from=effective_from,
+                    effective_to=effective_to,
+                )
+            )
+        else:
+            i += 1
+    return passages

--- a/packages/backend/rag/retrieve.py
+++ b/packages/backend/rag/retrieve.py
@@ -1,0 +1,70 @@
+import os
+import random
+from typing import Dict, Any, Tuple, Optional
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+from .normalize import normalize_text
+from .indexer import load_index
+from .types import Retrieval, Passage
+
+
+def _sort_key(p: Passage):
+    return (p["source"], p["clause_id"])
+
+
+def semantic_search(query: str, topk: int, vector_dir: str) -> Retrieval:
+    index, meta = load_index(vector_dir)
+
+    random.seed(13)
+    np.random.seed(13)
+    try:
+        import torch
+        torch.manual_seed(13)
+    except Exception:
+        pass
+
+    model = SentenceTransformer(meta["model"])
+    norm_q = normalize_text(query)
+    q_emb = model.encode([norm_q], normalize_embeddings=True).astype("float32")
+
+    k = max(topk, 1)
+    D, I = index.search(q_emb, k)
+    pairs = []
+    for dist, idx in zip(D[0], I[0]):
+        if idx == -1:
+            continue
+        passage = meta["passages"][idx]
+        pairs.append((float(dist), passage))
+
+    pairs.sort(key=lambda x: (x[0], _sort_key(x[1])))
+    results = [p for _, p in pairs[:topk]]
+    return Retrieval(query=query, topk=topk, results=results)
+
+
+def query_policy_for_claim_context(claim: Dict[str, Any], topk: int, vector_dir: str) -> Retrieval:
+    payer = claim.get("payer", {}).get("name", "")
+    cpts = [line.get("cpt", "") for line in claim.get("lines", [])]
+    mods = [m for line in claim.get("lines", []) for m in line.get("modifiers", []) if m]
+    sos = claim.get("provider", {}).get("siteOfService") or claim.get("provider", {}).get("site_of_service")
+
+    parts = []
+    if payer:
+        parts.append(payer)
+    parts.extend(cpts)
+    parts.extend(mods)
+    if sos:
+        parts.append(f"pos {sos}")
+    query = " ".join(parts)
+    return semantic_search(query, topk, vector_dir)
+
+
+def top_citations_for_issue(issue: str, cpt_pair: Optional[Tuple[str, str]], payer: Optional[str], topk: int, vector_dir: str) -> list[Passage]:
+    parts = [issue]
+    if cpt_pair:
+        parts.extend(list(cpt_pair))
+    if payer:
+        parts.append(payer)
+    retrieval = semantic_search(" ".join(parts), topk, vector_dir)
+    return retrieval["results"]

--- a/packages/backend/rag/types.py
+++ b/packages/backend/rag/types.py
@@ -1,0 +1,13 @@
+from typing import TypedDict, List, Optional
+
+class Passage(TypedDict):
+    text: str
+    source: str           # filename
+    clause_id: str        # e.g., "UHC-LCD-123 §3b"
+    effective_from: str   # YYYY-MM-DD
+    effective_to: Optional[str]  # None or YYYY-MM-DD
+
+class Retrieval(TypedDict):
+    query: str
+    topk: int
+    results: List[Passage]

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -7,3 +7,7 @@ orjson==3.10.*
 python-json-logger==2.0.*
 pytest==8.*
 httpx==0.27.*
+faiss-cpu==1.8.*
+sentence-transformers==3.0.*
+numpy==1.26.*
+scikit-learn==1.5.*

--- a/packages/backend/tests/test_rag_build_and_query.py
+++ b/packages/backend/tests/test_rag_build_and_query.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from packages.backend.rag.indexer import build_index
+from packages.backend.rag.retrieve import semantic_search, query_policy_for_claim_context
+
+CASE_MOD59 = {
+    "claimId": "CLM-1001",
+    "payer": {"name": "UnitedHealthcare", "planId": "UHC-GOLD-CA", "state": "CA"},
+    "patient": {"dob": "1962-05-14", "age": 63, "sex": "F"},
+    "provider": {"npi": "1093817465", "siteOfService": "11"},
+    "lines": [
+        {"cpt": "97012", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 180.00},
+        {"cpt": "97110", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 190.00},
+    ],
+    "attachments": [{"type": "progress_note", "id": "doc_123"}],
+    "history": [{"ts": "2025-09-05T10:00:00Z", "event": "created"}],
+    "notes": [
+        "Therapeutic exercise same session; distinct procedural service not indicated in line 1."
+    ],
+}
+
+
+POLICY_DIR = "packages/backend/data/policies"
+
+
+def test_build_and_query(tmp_path):
+    vector_dir = tmp_path / "vector"
+    _, meta = build_index(POLICY_DIR, str(vector_dir))
+    assert os.path.exists(vector_dir / "index.faiss")
+    assert os.path.exists(vector_dir / "meta.json")
+    assert meta["vector_dim"] == 384
+
+    q1 = "modifier 59 with 97012 and 97110 same date of service"
+    r1 = semantic_search(q1, 5, str(vector_dir))
+    assert any(p["clause_id"] == "UHC-LCD-123 §3b" for p in r1["results"])
+
+    q2 = "UnitedHealthcare 97012 97110 modifier 59"
+    r2 = semantic_search(q2, 3, str(vector_dir))
+    clauses = [p["clause_id"] for p in r2["results"][:3]]
+    assert "UHC-LCD-123 §3b" in clauses
+
+    r3 = semantic_search(q2, 5, str(vector_dir))
+    r4 = semantic_search(q2, 5, str(vector_dir))
+    assert r3 == r4
+
+    claim_ret = query_policy_for_claim_context(CASE_MOD59, 3, str(vector_dir))
+    top_clause = claim_ret["results"][0]["clause_id"]
+    assert "UHC-LCD-123" in top_clause or "Kaiser-ACL-22" in top_clause


### PR DESCRIPTION
## Summary
- introduce RAG module with FAISS indexer, semantic search, and policy query helpers
- seed synthetic payer policy corpus for deterministic unit tests
- configure backend for RAG (requirements and settings)

## Testing
- `pytest -q packages/backend/tests/test_rag_build_and_query.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python - <<'PY'
from packages.backend.rag.indexer import build_index
from packages.backend.rag.retrieve import semantic_search
vector_dir = './var/vector'
build_index('packages/backend/data/policies', vector_dir)
r = semantic_search('unitedhealthcare cpt 97012 with 97110 modifier 59 same dos', 3, vector_dir)
print(r)
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68bbdcb12044832291ba8bfaaa5c2109