### PR TITLE
feat: add deterministic claim tools

### DIFF
--- a/packages/backend/tests/test_tools_rules.py
+++ b/packages/backend/tests/test_tools_rules.py
@@ -1,0 +1,73 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
+from packages.backend.tools.code_rules import (
+    icd_cpt_validate,
+    modifier_rules,
+    suggest_recoding,
+)
+
+
+# Case 1: modifier -59 suggestion
+case_mod59 = {
+    "claimId": "C1",
+    "payer": {"name": "Demo"},
+    "provider": {"siteOfService": "11"},
+    "lines": [
+        {"cpt": "97012", "dx": ["M25.50"], "modifiers": []},
+        {"cpt": "97110", "dx": ["M25.50"], "modifiers": []},
+    ],
+}
+
+
+# Case 2: unspecific dx
+case_dx_unspecific = {
+    "claimId": "C2",
+    "payer": {"name": "Demo"},
+    "provider": {"siteOfService": "11"},
+    "lines": [
+        {"cpt": "97110", "dx": ["M25.50"], "modifiers": []}
+    ],
+}
+
+
+# Case 3: site of service doc requirement
+case_sos_note = {
+    "claimId": "C3",
+    "payer": {"name": "Demo"},
+    "provider": {"siteOfService": "11"},
+    "lines": [
+        {
+            "cpt": "77080",
+            "dx": ["M25.511"],
+            "modifiers": [],
+            "details": {"flags": ["imaging_generic"]},
+        }
+    ],
+}
+
+
+def test_modifier_rules_and_suggestion_stable():
+    issues = modifier_rules(case_mod59)
+    assert len(issues) == 1
+    assert issues[0]["issue"] == "modifier_missing"
+    assert "UHC-LCD-123 §3b" in issues[0]["policy_refs"]
+    # stability
+    assert issues == modifier_rules(case_mod59)
+    actions = suggest_recoding(case_mod59, issues)
+    assert actions[0]["line"] == 0
+    assert actions[0]["addModifier"] == "59"
+
+
+def test_icd_unspecific_suggestion_and_stability():
+    issues = icd_cpt_validate(case_dx_unspecific)
+    found = [i for i in issues if i["issue"] == "dx_unspecific"]
+    assert found
+    assert found[0]["details"]["to"] in {"M25.512", "M25.511", "M25.519"}
+    assert issues == icd_cpt_validate(case_dx_unspecific)
+
+
+def test_site_of_service_doc_missing():
+    issues = icd_cpt_validate(case_sos_note)
+    found = [i for i in issues if i["issue"] == "doc_missing"]
+    assert found
+    assert "BCBS-P123 §7" in found[0]["policy_refs"]
+    assert issues == icd_cpt_validate(case_sos_note)

--- a/packages/backend/tests/test_tools_templates.py
+++ b/packages/backend/tests/test_tools_templates.py
@@ -1,0 +1,36 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
+from packages.backend.tools.code_rules import modifier_rules, suggest_recoding
+from packages.backend.tools.templates import template_corrected_claim, template_appeal_letter
+
+case_mod59 = {
+    "claimId": "C1",
+    "payer": {"name": "Demo"},
+    "provider": {"siteOfService": "11"},
+    "lines": [
+        {"cpt": "97012", "dx": ["M25.50"], "modifiers": []},
+        {"cpt": "97110", "dx": ["M25.50"], "modifiers": []},
+    ],
+}
+
+
+def test_template_corrected_claim_pure_and_appends():
+    issues = modifier_rules(case_mod59)
+    actions = suggest_recoding(case_mod59, issues)
+    new_claim = template_corrected_claim(case_mod59, actions)
+    # input untouched
+    assert "59" not in case_mod59["lines"][0]["modifiers"]
+    # modifier added to first line
+    assert "59" in new_claim["lines"][0]["modifiers"]
+    assert "59" not in new_claim["lines"][1]["modifiers"]
+
+
+def test_template_appeal_letter():
+    passages = [
+        {"clause_id": "UHC-LCD-123 §3b", "text": "Traction with exercise policy."},
+        {"clause_id": "Med-XYZ §1", "text": "Sample clause."},
+    ]
+    letter = template_appeal_letter(case_mod59, "modifier 59 missing", passages)
+    md = letter["markdown"]
+    assert "C1" in md and "Demo" in md
+    assert "UHC-LCD-123 §3b" in md and "Med-XYZ §1" in md
+    assert len(md.split()) < 320

--- a/packages/backend/tools/__init__.py
+++ b/packages/backend/tools/__init__.py
@@ -1,0 +1,14 @@
+"""Deterministic utilities for claim rule validation and artifact generation."""
+from .code_rules import normalize_codes, icd_cpt_validate, modifier_rules, suggest_recoding
+from .templates import template_corrected_claim, template_appeal_letter
+from .edi import edi_to_claim
+
+__all__ = [
+    "normalize_codes",
+    "icd_cpt_validate",
+    "modifier_rules",
+    "suggest_recoding",
+    "template_corrected_claim",
+    "template_appeal_letter",
+    "edi_to_claim",
+]

--- a/packages/backend/tools/code_rules.py
+++ b/packages/backend/tools/code_rules.py
@@ -1,0 +1,146 @@
+"""Deterministic claim code validation and rule helpers."""
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from typing import Dict, List, Tuple
+
+from .data_rules import (
+    ICD10_REGEX,
+    CPT_REGEX,
+    MOD_REGEX,
+    MODIFIER_59_REQUIRED_PAIRS,
+    ICD_SPECIFICITY_SUGGESTIONS,
+    SITE_OF_SERVICE_RULES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Normalisation utilities
+# ---------------------------------------------------------------------------
+
+def normalize_codes(claim: Dict) -> Dict:
+    """Return a deep-copied claim with codes upper-cased and emptied items removed."""
+    c = deepcopy(claim)
+    for line in c.get("lines", []):
+        line["dx"] = [str(d).upper().strip() for d in line.get("dx", []) if str(d).strip()]
+        mods = [str(m).upper().strip() for m in line.get("modifiers", []) if str(m).strip()]
+        line["modifiers"] = mods
+    return c
+
+
+def _pair_key(a: str, b: str) -> Tuple[str, str]:
+    return tuple(sorted((a, b)))
+
+
+# ---------------------------------------------------------------------------
+# Validators
+# ---------------------------------------------------------------------------
+
+def icd_cpt_validate(claim: Dict) -> List[Dict]:
+    """Validate CPT/ICD formatting, specificity and site-of-service notes.
+
+    Returns a list of issue dictionaries sorted deterministically by (issue, line).
+    """
+    c = normalize_codes(claim)
+    issues: List[Dict] = []
+    pos = (c.get("provider") or {}).get("siteOfService")
+
+    for idx, line in enumerate(c.get("lines", [])):
+        cpt = line.get("cpt", "")
+        if not re.match(CPT_REGEX, cpt):
+            issues.append({"line": idx, "issue": "format_error", "why": f"Bad CPT {cpt}"})
+
+        for dx in line.get("dx", []):
+            if not re.match(ICD10_REGEX, dx):
+                issues.append({"line": idx, "issue": "format_error", "why": f"Bad ICD {dx}"})
+
+        for dx in line.get("dx", []):
+            if dx in ICD_SPECIFICITY_SUGGESTIONS:
+                issues.append(
+                    {
+                        "line": idx,
+                        "issue": "dx_unspecific",
+                        "why": f"{dx} is non-specific; consider site-specific alternative.",
+                        "details": {"from": dx, "to": ICD_SPECIFICITY_SUGGESTIONS[dx][0]},
+                        "policy_refs": ["Medicare-AB-2024-05 §4"],
+                    }
+                )
+                break
+
+        # Site-of-service notes requirement
+        if pos in SITE_OF_SERVICE_RULES:
+            details = line.get("details") or {}
+            flags: List[str] = []
+            if isinstance(details, dict):
+                for k in ("flags", "tags", "flag", "tag", "type", "category"):
+                    v = details.get(k)
+                    if isinstance(v, str):
+                        flags.append(v)
+                    elif isinstance(v, list):
+                        flags.extend([str(i) for i in v])
+            elif isinstance(details, list):
+                flags.extend([str(i) for i in details])
+            elif isinstance(details, str):
+                flags.append(details)
+
+            required = SITE_OF_SERVICE_RULES[pos]["notes_required_for"]
+            if any(f in required for f in flags):
+                issues.append(
+                    {
+                        "line": idx,
+                        "issue": "doc_missing",
+                        "why": f"POS {pos} requires documented rationale for imaging.",
+                        "policy_refs": sorted(SITE_OF_SERVICE_RULES[pos]["policy_refs"]),
+                    }
+                )
+
+    issues.sort(key=lambda x: (x["issue"], x["line"]))
+    return issues
+
+
+def modifier_rules(claim: Dict) -> List[Dict]:
+    """Detect CPT pairs that commonly require modifier -59 when billed together."""
+    c = normalize_codes(claim)
+    issues: List[Dict] = []
+    cpts = [ln.get("cpt", "") for ln in c.get("lines", [])]
+
+    for (a, b), meta in MODIFIER_59_REQUIRED_PAIRS.items():
+        if a in cpts and b in cpts:
+            idx_a, idx_b = cpts.index(a), cpts.index(b)
+            target = min(idx_a, idx_b)
+            has_59 = any("59" in ln.get("modifiers", []) for ln in c.get("lines", []))
+            if not has_59:
+                issues.append(
+                    {
+                        "line": target,
+                        "issue": "modifier_missing",
+                        "why": meta["why"],
+                        "policy_refs": sorted(meta.get("policy_refs", [])),
+                    }
+                )
+    issues.sort(key=lambda x: (x["issue"], x["line"]))
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Suggestions
+# ---------------------------------------------------------------------------
+
+def suggest_recoding(claim: Dict, issues: List[Dict]) -> List[Dict]:
+    """Generate deterministic recoding action suggestions given issue list."""
+    actions: List[Dict] = []
+    for iss in issues:
+        if iss["issue"] == "modifier_missing":
+            cite = None
+            if iss.get("policy_refs"):
+                cite = sorted(iss["policy_refs"])[0]
+            actions.append({"line": iss["line"], "addModifier": "59", "cite": cite})
+        elif iss["issue"] == "dx_unspecific":
+            details = iss.get("details") or {}
+            to = details.get("to")
+            frm = details.get("from")
+            if to and frm:
+                actions.append({"line": iss["line"], "replaceDx": {"from": frm, "to": to}})
+    actions.sort(key=lambda a: (0 if "addModifier" in a else 1, a["line"]))
+    return actions

--- a/packages/backend/tools/data_rules.py
+++ b/packages/backend/tools/data_rules.py
@@ -1,0 +1,24 @@
+# CPT–ICD and modifier demo rules (synthetic, not clinical advice)
+ICD10_REGEX = r"^[A-TV-Z][0-9][A-Z0-9](?:\.[A-Z0-9]{1,4})?$"  # allow letter-digit, dot variants
+CPT_REGEX   = r"^[0-9]{5}[A-Z0-9]?$"                          # allow HCPCS letter suffix
+MOD_REGEX   = r"^[A-Z0-9]{2}$"
+
+# Known CPT pairs that often require -59 when same DOS unless documentation justifies separation
+MODIFIER_59_REQUIRED_PAIRS = {
+    # (primary, paired) order-insensitive check will be used
+    ("97012", "97110"): {
+        "policy_refs": ["UHC-LCD-123 §3b", "Kaiser-ACL-22 §1", "Cigna-MED-77 §2"],
+        "why": "Traction (97012) with therapeutic exercise (97110) on same DOS may need -59.",
+    }
+}
+
+# ICD specificity suggestions for M25.50 → site-specific M25.51x variants (demo mapping)
+ICD_SPECIFICITY_SUGGESTIONS = {
+    "M25.50": ["M25.512", "M25.511", "M25.519"]  # shoulder pain left/right/unspecified
+}
+
+# Site-of-service constraints (demo)
+SITE_OF_SERVICE_RULES = {
+    # POS 11 is physician office; require documentation rationale for certain imaging/bundles
+    "11": {"notes_required_for": ["imaging_generic"], "policy_refs": ["BCBS-P123 §7"]}
+}

--- a/packages/backend/tools/edi.py
+++ b/packages/backend/tools/edi.py
@@ -1,0 +1,31 @@
+"""Tiny 837-like claim normaliser."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def edi_to_claim(edi: Dict) -> Dict:
+    """Normalise an 837-like dict into canonical claim dict used by tools.
+
+    Expected shape (minimal):
+    {
+        "claim": {"id": str},
+        "payer": {"name": str},
+        "patient": {...},
+        "provider": {"siteOfService": str},
+        "lines": [
+            {"cpt": str, "dx": [str], "modifiers": [str]}
+        ]
+    }
+    """
+    claim_section = edi.get("claim") or {}
+    if "id" not in claim_section:
+        raise ValueError("claim.id required")
+    out = {
+        "claimId": claim_section["id"],
+        "payer": edi.get("payer") or {},
+        "patient": edi.get("patient") or {},
+        "provider": edi.get("provider") or {},
+        "lines": edi.get("lines") or [],
+    }
+    return out

--- a/packages/backend/tools/templates.py
+++ b/packages/backend/tools/templates.py
@@ -1,0 +1,54 @@
+"""Pure artifact generators for claim corrections and appeal letters."""
+from __future__ import annotations
+
+from copy import deepcopy
+from textwrap import shorten
+from typing import Dict, List
+
+
+def template_corrected_claim(claim: Dict, actions: List[Dict]) -> Dict:
+    """Apply recoding actions immutably and return new corrected claim dict."""
+    out = deepcopy(claim)
+    for act in actions:
+        ln = out.get("lines", [])[act["line"]]
+        if "addModifier" in act:
+            mod = act["addModifier"].strip().upper()
+            if mod and mod not in ln.get("modifiers", []):
+                ln.setdefault("modifiers", []).append(mod)
+        if "replaceDx" in act:
+            frm = act["replaceDx"].get("from", "").upper()
+            to = act["replaceDx"].get("to", "").upper()
+            ln["dx"] = [to if d.upper() == frm else d for d in ln.get("dx", [])]
+        # clean modifiers: remove empties, dedup, preserve order
+        seen = set()
+        cleaned: List[str] = []
+        for m in ln.get("modifiers", []):
+            m = m.strip().upper()
+            if m and m not in seen:
+                seen.add(m)
+                cleaned.append(m)
+        ln["modifiers"] = cleaned
+    return out
+
+
+def template_appeal_letter(claim: Dict, denial_reason: str, passages: List[Dict]) -> Dict:
+    """Generate deterministic markdown appeal letter with policy citations."""
+    claim_id = claim.get("claimId", "")
+    payer = (claim.get("payer") or {}).get("name", "Payer")
+    cites: List[str] = []
+    bullets: List[str] = []
+    for p in passages[:3]:
+        cid = p.get("clause_id") or p.get("clauseId") or ""
+        cites.append(cid)
+        text = p.get("text") or p.get("passage") or ""
+        bullets.append(f"- **{cid}**: {shorten(text.strip(), width=120, placeholder='…')}")
+    body = (
+        f"# Level-1 Appeal — {claim_id}\n\n"
+        f"**To:** {payer}  \n"
+        f"**Subject:** Reconsideration Request — Denial (“{denial_reason}”)\n\n"
+        f"We request reconsideration for claim **{claim_id}**. The submitted services are supported by documentation and applicable policy guidance:\n\n"
+        f"{chr(10).join(bullets)}\n\n"
+        "**Requested Action:** Reverse the denial and reprocess the claim in accordance with the cited clauses.\n\n"
+        "Sincerely,\nRevenue Integrity Team"
+    )
+    return {"markdown": body.strip(), "cites": [c for c in cites if c]}


### PR DESCRIPTION
## Summary
- add rule tables and deterministic validators for ICD/CPT/59 pairs
- add recoding suggestions and artifact templates
- cover tools with unit tests

## Testing
- `pytest -q packages/backend/tests/test_tools_rules.py packages/backend/tests/test_tools_templates.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbdf10b11c8322a3dfa33437bd2eb6