### PR TITLE
feat: implement deterministic actor and audit logging

### DIFF
--- a/packages/backend/agents/__init__.py
+++ b/packages/backend/agents/__init__.py
@@ -1,4 +1,5 @@
 from .assessor_agent import assess_claim
 from .planner_agent import make_plan
+from .actor_agent import act_on_plan
 
-__all__ = ["assess_claim", "make_plan"]
+__all__ = ["assess_claim", "make_plan", "act_on_plan"]

--- a/packages/backend/agents/actor_agent.py
+++ b/packages/backend/agents/actor_agent.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+from typing import Dict, Any, List
+from hashlib import sha256
+from copy import deepcopy
+
+from ..tools.templates import template_corrected_claim, template_appeal_letter
+
+
+def _sha256(obj: Any) -> str:
+    import json
+    b = json.dumps(obj, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return sha256(b).hexdigest()
+
+
+def act_on_plan(claim: Dict, plan_result: Dict, evidence: List[Dict] | None = None) -> Dict[str, Any]:
+    """Apply the chosen plan to the claim and return artifact details."""
+    claim_in = deepcopy(claim)
+    plans = plan_result.get("plans") or []
+    chosen = None
+    for p in plans:
+        if p.get("type") == "recoding":
+            chosen = p
+            break
+    if chosen is None and plans:
+        chosen = plans[0]
+    if not chosen:
+        raise ValueError("No plan provided")
+
+    if chosen["type"] == "recoding":
+        actions = chosen.get("actions") or []
+        corrected = template_corrected_claim(claim_in, actions)
+        return {
+            "artifactType": "corrected_claim",
+            "payload": corrected,
+            "meta": {
+                "input_sha256": _sha256(claim_in),
+                "output_sha256": _sha256(corrected),
+                "actions": actions,
+                "plan_type": "recoding",
+            },
+        }
+
+    reason = " / ".join([a.get("reason", "appeal") for a in chosen.get("actions", [])]) or "appeal"
+    passages = evidence or []
+    letter = template_appeal_letter(claim_in, reason, passages)
+    return {
+        "artifactType": "appeal_letter",
+        "payload": letter,
+        "meta": {
+            "input_sha256": _sha256(claim_in),
+            "output_sha256": _sha256(letter),
+            "actions": chosen.get("actions") or [],
+            "plan_type": "appeal",
+        },
+    }

--- a/packages/backend/core/audit.py
+++ b/packages/backend/core/audit.py
@@ -1,19 +1,26 @@
-import json
-import os
-from datetime import datetime
-from hashlib import sha256
+from __future__ import annotations
+from pathlib import Path
+from datetime import datetime, timezone
+import json, hashlib
 from .config import Settings
 
 
+def _day_path() -> Path:
+    base = Path(Settings().AUDIT_PATH)
+    base.mkdir(parents=True, exist_ok=True)
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return base / f"{day}.jsonl"
+
+
 def audit_write(kind: str, payload: dict) -> None:
-    settings = Settings()
-    ts = datetime.utcnow().strftime("%Y-%m-%d")
-    path = os.path.join(settings.AUDIT_PATH, f"{ts}.jsonl")
-    record = {
-        "ts": datetime.utcnow().isoformat() + "Z",
+    rec = {
+        "ts": datetime.now(timezone.utc).isoformat(),
         "kind": kind,
-        "sha256": sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest(),
+        "sha256": hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest(),
         "payload": payload,
     }
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(json.dumps(record) + "\n")
+    path = _day_path()
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n")

--- a/packages/backend/routers/act.py
+++ b/packages/backend/routers/act.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
 from fastapi import APIRouter
 from pydantic import BaseModel
+from typing import Dict, Any, List
+
+from ..schemas import Claim, PlanResult, ActResult, AssessmentResult
+from ..agents.actor_agent import act_on_plan
 from ..core.audit import audit_write
-from ..schemas import Claim, PlanResult, ActResult
 
 router = APIRouter(prefix="/v1", tags=["rcm"])
 
@@ -9,17 +13,39 @@ router = APIRouter(prefix="/v1", tags=["rcm"])
 class ActRequest(BaseModel):
     claim: Claim
     plan: PlanResult
+    assessment: AssessmentResult | None = None
 
 
 @router.post("/act", response_model=ActResult)
 def act(body: ActRequest) -> ActResult:
-    # For demo: if first plan is recoding, echo corrected JSON; else return letter md
-    if body.plan.plans and body.plan.plans[0].type == "recoding":
-        corrected = body.claim.model_dump() if hasattr(body.claim, "model_dump") else body.claim.__dict__
-        # apply the modifier (demo-safe)
-        corrected["lines"][0]["modifiers"] = ["59"]
-        artifact = {"artifactType":"corrected_claim","payload":corrected}
-    else:
-        artifact = {"artifactType":"appeal_letter","payload":{"markdown":"# Appeal\n...","cites":["CMS-NCD-456 §2"]}}
-    audit_write(kind="act", payload=artifact)
-    return ActResult(**artifact)
+    claim_dict = (
+        body.claim.model_dump(by_alias=True) if hasattr(body.claim, "model_dump") else body.claim
+    )
+    plan_dict = (
+        body.plan.model_dump(by_alias=True) if hasattr(body.plan, "model_dump") else body.plan
+    )
+    evidence: List[Dict[str, Any]] = []
+    if body.assessment is not None:
+        asmt = (
+            body.assessment.model_dump(by_alias=True)
+            if hasattr(body.assessment, "model_dump")
+            else body.assessment
+        )
+        for e in asmt.get("evidence", []):
+            passage = {
+                "text": e.get("passage", ""),
+                "clause_id": e.get("clause_id") or e.get("clauseId"),
+                "source": e.get("source"),
+            }
+            evidence.append(passage)
+    artifact = act_on_plan(claim_dict, plan_dict, evidence=evidence)
+
+    audit_write(
+        "act",
+        {
+            "artifactType": artifact["artifactType"],
+            "meta": artifact.get("meta"),
+        },
+    )
+
+    return ActResult(**{k: v for k, v in artifact.items() if k in ("artifactType", "payload")})

--- a/packages/backend/tests/test_act_audit.py
+++ b/packages/backend/tests/test_act_audit.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+from pathlib import Path
+import json
+
+from packages.backend.app import app
+from packages.backend.core.config import Settings
+
+CASE = {
+    "claimId": "CLM-1001",
+    "payer": {"name": "UnitedHealthcare", "planId": "UHC-GOLD-CA", "state": "CA"},
+    "patient": {"dob": "1962-05-14", "age": 63, "sex": "F"},
+    "provider": {"npi": "1093817465", "siteOfService": "11"},
+    "lines": [
+        {"cpt": "97012", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 180.00},
+        {"cpt": "97110", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 190.00},
+    ],
+    "attachments": [{"type": "progress_note", "id": "doc_123"}],
+    "history": [{"ts": "2025-09-05T10:00:00Z", "event": "created"}],
+    "notes": [
+        "Therapeutic exercise same session; distinct procedural service not indicated in line 1."
+    ],
+}
+
+
+def test_act_writes_audit(tmp_path, monkeypatch):
+    monkeypatch.setenv("AUDIT_PATH", str(tmp_path / "audit"))
+    c = TestClient(app)
+
+    assess = c.post("/v1/assess", json=CASE).json()
+    plan = c.post("/v1/plan", json={"claim": CASE, "assessment": assess}).json()
+
+    res = c.post("/v1/act", json={"claim": CASE, "plan": plan, "assessment": assess})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["artifactType"] in ("corrected_claim", "appeal_letter")
+
+    audit_dir = Path(Settings().AUDIT_PATH)
+    files = list(audit_dir.glob("*.jsonl"))
+    assert files, "no audit file written"
+    content = files[0].read_text(encoding="utf-8").strip().splitlines()
+    assert len(content) >= 1
+    rec = json.loads(content[-1])
+    assert rec["kind"] == "act"
+    assert "sha256" in rec and len(rec["sha256"]) == 64


### PR DESCRIPTION
## Summary
- add actor agent that produces corrected claims or appeal letters using templates
- wire /v1/act router to actor agent and record append-only audit logs
- upgrade audit writer to JSONL WORM with sha256 hashing
- add regression test ensuring act flow writes audited record

## Testing
- `pytest -q packages/backend/tests/test_act_audit.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68bbe595a58c832288a3455ec1913e85