### PR TITLE
Implement brief ranker service and unified tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,11 @@ typecheck:
 	[ -d packages/contracts-py ] && (cd packages/contracts-py && mypy .) || true
 
 test:
-	@echo "== test =="
-	npm test --workspaces --silent || true
-	[ -d packages/contracts-py ] && (cd packages/contracts-py && pytest -q) || true
+	# Backend Python tests
+	[ -d packages/backend ] && (cd packages/backend && pytest -q) || true
+	# TS tests (optional; won't fail if absent)
+	[ -d packages/frontend ] && (cd packages/frontend && npm test --silent) || true
+	[ -d packages/contracts ] && (cd packages/contracts && npm test --silent) || true
 
 build:
 	docker compose -f infra/docker-compose.yml build

--- a/packages/backend/core/config.py
+++ b/packages/backend/core/config.py
@@ -11,6 +11,10 @@ class Settings(BaseSettings):
     AUDIT_PATH: str = "./var/audit"
     LOG_LEVEL: str = "INFO"
     RAG_TOPK_DEFAULT: int = 5
+    W_DELTA: float = 0.5
+    W_FEAS: float = 0.25
+    W_URG: float = 0.15
+    W_FIT: float = 0.10
     RISK_WEIGHTS: dict = {
         "modifier_missing": 0.35,
         "dx_unspecific": 0.20,

--- a/packages/backend/data/examples/claims/case_dx_incompat.json
+++ b/packages/backend/data/examples/claims/case_dx_incompat.json
@@ -1,0 +1,11 @@
+{
+  "claimId": "CLM-2001",
+  "payer": {"name": "UnitedHealthcare", "planId": "UHC-GOLD-CA", "state": "CA"},
+  "patient": {"dob": "1963-02-10", "age": 62, "sex": "M"},
+  "provider": {"npi": "1093817465", "siteOfService": "11"},
+  "lines": [
+    {"cpt": "97110", "dx": ["Z00.00"], "modifiers": [], "units": 1, "charge": 200.0}
+  ],
+  "expDeltaUsd": 410,
+  "deadline": "2025-09-20"
+}

--- a/packages/backend/data/examples/claims/case_mod59.json
+++ b/packages/backend/data/examples/claims/case_mod59.json
@@ -1,0 +1,17 @@
+{
+  "claimId": "CLM-1001",
+  "payer": {"name": "UnitedHealthcare", "planId": "UHC-GOLD-CA", "state": "CA"},
+  "patient": {"dob": "1962-05-14", "age": 63, "sex": "F"},
+  "provider": {"npi": "1093817465", "siteOfService": "11"},
+  "lines": [
+    {"cpt": "97012", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 180.0},
+    {"cpt": "97110", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 190.0}
+  ],
+  "attachments": [{"type": "progress_note", "id": "doc_123"}],
+  "history": [{"ts": "2025-09-05T10:00:00Z", "event": "created"}],
+  "notes": [
+    "Therapeutic exercise same session; distinct procedural service not indicated in line 1."
+  ],
+  "expDeltaUsd": 126,
+  "deadline": "2025-09-12"
+}

--- a/packages/backend/data/examples/claims/case_ncd.json
+++ b/packages/backend/data/examples/claims/case_ncd.json
@@ -1,0 +1,11 @@
+{
+  "claimId": "CLM-3001",
+  "payer": {"name": "Medicare", "planId": "MC-NCD", "state": "CA"},
+  "patient": {"dob": "1959-11-21", "age": 65, "sex": "F"},
+  "provider": {"npi": "1093817465", "siteOfService": "11"},
+  "lines": [
+    {"cpt": "97110", "dx": ["M25.50"], "modifiers": [], "units": 1, "charge": 210.0}
+  ],
+  "expDeltaUsd": 260,
+  "deadline": "2025-09-10"
+}

--- a/packages/backend/data/examples/claims/case_sos.json
+++ b/packages/backend/data/examples/claims/case_sos.json
@@ -1,0 +1,18 @@
+{
+  "claimId": "CLM-4001",
+  "payer": {"name": "BlueCross", "planId": "BCBS-P123", "state": "CA"},
+  "patient": {"dob": "1975-03-02", "age": 50, "sex": "M"},
+  "provider": {"npi": "1093817465", "siteOfService": "11"},
+  "lines": [
+    {
+      "cpt": "77080",
+      "dx": ["M25.511"],
+      "modifiers": [],
+      "units": 1,
+      "charge": 160.0,
+      "details": {"flags": ["imaging_generic"]}
+    }
+  ],
+  "expDeltaUsd": 180,
+  "deadline": "2025-09-08"
+}

--- a/packages/backend/routers/brief.py
+++ b/packages/backend/routers/brief.py
@@ -1,15 +1,16 @@
 from fastapi import APIRouter, Query
+
 from ..schemas import BriefResult
+from ..core.config import Settings
+from ..services import compute_brief
+
+EXAMPLES_DIR = "packages/backend/data/examples/claims"
 
 router = APIRouter(prefix="/v1", tags=["rcm"])
 
 
 @router.get("/brief", response_model=BriefResult)
 def brief(user_id: str = Query(...), date: str = Query(...)) -> BriefResult:
-    return BriefResult(
-        highlights=["UHC-LCD-123 updated on 2025-08-01"],
-        queue=[
-            {"claimId":"CLM-1001","score":0.91,"expDeltaUsd":126.0,"why":["modifier"],"etaMin":2},
-            {"claimId":"CLM-1002","score":0.86,"expDeltaUsd":410.0,"why":["NCD"],"etaMin":6,"deadline":"2025-09-12"},
-        ],
-    )
+    vec_dir = Settings().VECTOR_PATH
+    res = compute_brief(user_id, date, vec_dir, EXAMPLES_DIR)
+    return BriefResult.model_validate(res)

--- a/packages/backend/services/__init__.py
+++ b/packages/backend/services/__init__.py
@@ -1,0 +1,3 @@
+from .brief import compute_brief
+
+__all__ = ["compute_brief"]

--- a/packages/backend/services/brief.py
+++ b/packages/backend/services/brief.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import date, datetime
+from typing import Any, Dict, List
+
+from ..agents.assessor_agent import assess_claim
+from ..core.config import Settings
+
+_PS_MAP = {
+    "modifier_missing": 0.75,
+    "dx_unspecific": 0.55,
+    "doc_missing": 0.50,
+    "dx_incompatibility": 0.45,
+}
+_EFFORT_MAP = {
+    "modifier_missing": 2,
+    "dx_unspecific": 5,
+    "doc_missing": 6,
+    "dx_incompatibility": 8,
+}
+
+
+def _deadline_score(base: date, dl: str | None) -> float:
+    if not dl:
+        return 0.2
+    try:
+        d = datetime.fromisoformat(dl).date()
+    except Exception:
+        return 0.2
+    diff = (d - base).days
+    if diff <= 3:
+        return 1.0
+    if diff <= 7:
+        return 0.6
+    return 0.3
+
+
+def _user_fit(user_id: str, issue: str) -> float:
+    if user_id == "U1" and issue == "modifier_missing":
+        return 0.8
+    if user_id == "U2" and issue == "doc_missing":
+        return 0.8
+    return 0.5
+
+
+def compute_brief(user_id: str, date: str, vector_dir: str, examples_dir: str) -> Dict[str, Any]:
+    """Returns BriefResult-like dict with highlights[] and queue[]. Deterministic."""
+    settings = Settings()
+    base_date = datetime.fromisoformat(date).date()
+
+    items: List[Dict[str, Any]] = []
+    for fname in sorted(os.listdir(examples_dir)):
+        if not fname.endswith('.json'):
+            continue
+        path = os.path.join(examples_dir, fname)
+        with open(path, 'r', encoding='utf-8') as f:
+            raw = json.load(f)
+        exp_delta = float(raw.pop('expDeltaUsd', 120))
+        deadline = raw.pop('deadline', None)
+        claim = raw
+
+        assess = assess_claim(claim, vector_dir)
+        drivers = assess.get('drivers') or []
+        primary = drivers[0]['issue'] if drivers else 'other'
+        p_success = _PS_MAP.get(primary, 0.5)
+        effort = _EFFORT_MAP.get(primary, 5)
+
+        ev = assess.get('evidence') or []
+        clause = None
+        if ev:
+            clause = ev[0].get('clauseId') or ev[0].get('source')
+        why: List[str] = [primary]
+        if clause:
+            why.append(clause)
+
+        delta_norm = min(exp_delta / 1000.0, 1.0)
+        feas = p_success / effort
+        urg = _deadline_score(base_date, deadline)
+        fit = _user_fit(user_id, primary)
+        score = (
+            settings.W_DELTA * delta_norm
+            + settings.W_FEAS * feas
+            + settings.W_URG * urg
+            + settings.W_FIT * fit
+        )
+
+        item: Dict[str, Any] = {
+            'claimId': claim.get('claimId', fname.rsplit('.', 1)[0]),
+            'score': score,
+            'expDeltaUsd': exp_delta,
+            'why': why,
+            'etaMin': effort,
+        }
+        if deadline:
+            item['deadline'] = deadline
+        items.append(item)
+
+    items.sort(key=lambda x: (-x['score'], -x['expDeltaUsd'], x['claimId']))
+
+    highlights = [
+        "UHC-LCD-123 remains effective 2024-01-01 →",
+        "CMS-NCD-456 guidance updated 2024-05-15 →",
+    ]
+    return {'highlights': highlights, 'queue': items}

--- a/packages/backend/tests/test_brief_service.py
+++ b/packages/backend/tests/test_brief_service.py
@@ -1,0 +1,25 @@
+import os, sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from packages.backend.rag.indexer import build_index
+from packages.backend.services import compute_brief
+
+POLICY_DIR = "packages/backend/data/policies"
+EXAMPLES_DIR = "packages/backend/data/examples/claims"
+
+
+def test_compute_brief(tmp_path):
+    vector_dir = tmp_path / "vector"
+    build_index(POLICY_DIR, str(vector_dir))
+    out1 = compute_brief("U1", "2025-09-06", str(vector_dir), EXAMPLES_DIR)
+    out2 = compute_brief("U1", "2025-09-06", str(vector_dir), EXAMPLES_DIR)
+
+    assert out1["highlights"]
+    assert len(out1["queue"]) >= 4
+    top = out1["queue"][0]
+    for key in ["claimId", "score", "expDeltaUsd", "why", "etaMin"]:
+        assert key in top
+    assert top["why"][0] in {"modifier_missing", "dx_unspecific", "doc_missing", "dx_incompatibility"}
+    assert out1["queue"] == out2["queue"]

--- a/packages/backend/tests/test_end_to_end_flow.py
+++ b/packages/backend/tests/test_end_to_end_flow.py
@@ -1,0 +1,47 @@
+import os, sys, time
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from fastapi.testclient import TestClient
+from packages.backend.rag.indexer import build_index
+
+POLICY_DIR = "packages/backend/data/policies"
+CLAIM = {
+    "claimId": "CLM-1001",
+    "payer": {"name": "UnitedHealthcare", "planId": "UHC-GOLD-CA", "state": "CA"},
+    "patient": {"dob": "1962-05-14", "age": 63, "sex": "F"},
+    "provider": {"npi": "1093817465", "siteOfService": "11"},
+    "lines": [
+        {"cpt": "97012", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 180.0},
+        {"cpt": "97110", "dx": ["M25.50"], "modifiers": [""], "units": 1, "charge": 190.0},
+    ],
+    "attachments": [{"type": "progress_note", "id": "doc_123"}],
+    "history": [{"ts": "2025-09-05T10:00:00Z", "event": "created"}],
+    "notes": [
+        "Therapeutic exercise same session; distinct procedural service not indicated in line 1.",
+    ],
+}
+
+
+
+def test_end_to_end(tmp_path):
+    os.environ["VECTOR_PATH"] = str(tmp_path / "vector")
+    from packages.backend.app import app  # import after env var
+
+    build_index(POLICY_DIR, os.environ["VECTOR_PATH"])
+    c = TestClient(app)
+
+    start = time.perf_counter()
+    assess = c.post("/v1/assess", json=CLAIM).json()
+    plan = c.post("/v1/plan", json={"claim": CLAIM, "assessment": assess}).json()
+    act = c.post("/v1/act", json={"claim": CLAIM, "plan": plan}).json()
+    brief = c.get("/v1/brief", params={"user_id": "U1", "date": "2025-09-06"}).json()
+    elapsed = time.perf_counter() - start
+
+    assert act["artifactType"] in {"corrected_claim", "appeal_letter"}
+    assert isinstance(act["payload"], dict)
+    assert len(brief["queue"]) >= 4
+    assert 0.0 <= brief["queue"][0]["score"] <= 1.0
+    assert any(item["claimId"] == CLAIM["claimId"] for item in brief["queue"])
+    assert elapsed < 0.5

--- a/packages/backend/tools/code_rules.py
+++ b/packages/backend/tools/code_rules.py
@@ -12,6 +12,7 @@ from .data_rules import (
     MODIFIER_59_REQUIRED_PAIRS,
     ICD_SPECIFICITY_SUGGESTIONS,
     SITE_OF_SERVICE_RULES,
+    DX_CPT_INCOMPATIBLE_PAIRS,
 )
 
 
@@ -64,6 +65,20 @@ def icd_cpt_validate(claim: Dict) -> List[Dict]:
                         "why": f"{dx} is non-specific; consider site-specific alternative.",
                         "details": {"from": dx, "to": ICD_SPECIFICITY_SUGGESTIONS[dx][0]},
                         "policy_refs": ["Medicare-AB-2024-05 §4"],
+                    }
+                )
+                break
+
+        for dx in line.get("dx", []):
+            key = (cpt, dx)
+            if key in DX_CPT_INCOMPATIBLE_PAIRS:
+                meta = DX_CPT_INCOMPATIBLE_PAIRS[key]
+                issues.append(
+                    {
+                        "line": idx,
+                        "issue": "dx_incompatibility",
+                        "why": meta["why"],
+                        "policy_refs": sorted(meta.get("policy_refs", [])),
                     }
                 )
                 break

--- a/packages/backend/tools/data_rules.py
+++ b/packages/backend/tools/data_rules.py
@@ -22,3 +22,11 @@ SITE_OF_SERVICE_RULES = {
     # POS 11 is physician office; require documentation rationale for certain imaging/bundles
     "11": {"notes_required_for": ["imaging_generic"], "policy_refs": ["BCBS-P123 §7"]}
 }
+
+# CPT-ICD incompatibility demo pairs
+DX_CPT_INCOMPATIBLE_PAIRS = {
+    ("97110", "Z00.00"): {
+        "policy_refs": ["NCD-001 §1"],
+        "why": "Therapeutic exercise not covered for general checkup.",
+    }
+}


### PR DESCRIPTION
## Summary
- implement deterministic Brief service with scoring for expected savings, feasibility, urgency, and user fit
- wire /v1/brief route and seed example claims for ranking demo
- add unified `make test` target and end-to-end plus brief service tests

## Testing
- `python -m pytest -q packages/backend/tests/test_brief_service.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python -m pytest -q packages/backend/tests/test_end_to_end_flow.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `make test` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68bbe76a24d88322909614a00d60d5ec