### PR TITLE
feat(frontend): add React console scaffold

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codexia Console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,10 +1,31 @@
 {
-  "name": "@codexia/frontend",
-  "version": "1.0.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "license": "MIT",
+  "name": "codexia-frontend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 5173",
+    "lint": "eslint --ext .ts,.tsx src",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
   "dependencies": {
-    "@codexia/contracts": "1.0.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2",
+    "lucide-react": "^0.453.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2",
+    "vitest": "^2.0.5",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^9.9.0",
+    "@types/node": "^20.11.30",
+    "@vitejs/plugin-react": "^4.3.1"
   }
 }

--- a/packages/frontend/public/logo.svg
+++ b/packages/frontend/public/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+  <text x="0" y="15" font-size="15">Codexia</text>
+</svg>

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,0 +1,16 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import ClaimWorkbench from './routes/ClaimWorkbench';
+import MorningBrief from './routes/MorningBrief';
+import Header from './components/Header';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Header />
+      <Routes>
+        <Route path="/" element={<ClaimWorkbench />} />
+        <Route path="/brief" element={<MorningBrief />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/packages/frontend/src/components/ArtifactViewer.tsx
+++ b/packages/frontend/src/components/ArtifactViewer.tsx
@@ -1,0 +1,48 @@
+import { useContext } from 'react';
+import { WorkbenchContext } from '../routes/ClaimWorkbench';
+
+export default function ArtifactViewer() {
+  const { artifact } = useContext(WorkbenchContext);
+  if (!artifact) return null;
+
+  if (artifact.artifactType === 'corrected_claim' && artifact.correctedClaim) {
+    const text = JSON.stringify(artifact.correctedClaim, null, 2);
+    function download() {
+      const blob = new Blob([text], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'corrected-claim.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+    return (
+      <div>
+        <h3>Artifact</h3>
+        <pre>{text}</pre>
+        <button onClick={download}>Download JSON</button>
+      </div>
+    );
+  }
+
+  if (artifact.artifactType === 'appeal_letter' && artifact.appealLetter) {
+    const text = artifact.appealLetter;
+    function download() {
+      const blob = new Blob([text], { type: 'text/markdown' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'appeal.md';
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+    return (
+      <div>
+        <h3>Artifact</h3>
+        <pre>{text}</pre>
+        <button onClick={download}>Download .md</button>
+      </div>
+    );
+  }
+  return null;
+}

--- a/packages/frontend/src/components/AssessmentView.tsx
+++ b/packages/frontend/src/components/AssessmentView.tsx
@@ -1,0 +1,33 @@
+import { useContext } from 'react';
+import { WorkbenchContext } from '../routes/ClaimWorkbench';
+
+interface Props {
+  onPlan: () => void;
+}
+
+export default function AssessmentView({ onPlan }: Props) {
+  const { assessment } = useContext(WorkbenchContext);
+  if (!assessment) return null;
+  return (
+    <div>
+      <h3>Assessment</h3>
+      <div>Risk: {Math.round(assessment.risk * 100)}%</div>
+      <ul>
+        {assessment.drivers.slice(0, 3).map((d, i) => (
+          <li key={i}>{d.issue}</li>
+        ))}
+      </ul>
+      <details>
+        <summary>Evidence</summary>
+        <ul>
+          {assessment.evidence.map((e, i) => (
+            <li key={i}>
+              {e.source}:{e.clauseId} {e.snippet}
+            </li>
+          ))}
+        </ul>
+      </details>
+      <button onClick={onPlan}>Plan</button>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ClaimEditor.tsx
+++ b/packages/frontend/src/components/ClaimEditor.tsx
@@ -1,0 +1,47 @@
+import { useToast } from '../lib/ui';
+import React from 'react';
+
+const samples: Record<string, any> = {
+  'mod-59': { lines: [{ modifiers: [] }] },
+  'dx-incompat': { sample: true }
+};
+
+interface Props {
+  text: string;
+  setText: (t: string) => void;
+  onAssess: () => void;
+}
+
+export default function ClaimEditor({ text, setText, onAssess }: Props) {
+  const toast = useToast();
+
+  function format() {
+    try {
+      setText(JSON.stringify(JSON.parse(text), null, 2));
+    } catch {
+      toast('Invalid JSON');
+    }
+  }
+
+  function load(name: string) {
+    setText(JSON.stringify(samples[name], null, 2));
+  }
+
+  return (
+    <div>
+      <h3>Claim</h3>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={20}
+        style={{ width: '100%' }}
+      />
+      <div className="flex flex-wrap gap-2 mt-2">
+        <button onClick={format}>Format JSON</button>
+        <button onClick={onAssess}>Assess (⌘/Ctrl+Enter)</button>
+        <button onClick={() => load('mod-59')}>Load Sample: mod-59</button>
+        <button onClick={() => load('dx-incompat')}>Load Sample: dx-incompat</button>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -1,0 +1,20 @@
+import { NavLink } from 'react-router-dom';
+
+export default function Header() {
+  return (
+    <header className="p-2 border-b flex justify-between items-center">
+      <div className="flex items-center gap-4">
+        <img src="/logo.svg" alt="logo" className="h-6" />
+        <nav className="flex gap-4">
+          <NavLink to="/" end>Workbench</NavLink>
+          <NavLink to="/brief">Morning Brief</NavLink>
+        </nav>
+      </div>
+      <div className="flex gap-2">
+        <button>New</button>
+        <button>Load Sample</button>
+        <button>Save</button>
+      </div>
+    </header>
+  );
+}

--- a/packages/frontend/src/components/PlanChooser.tsx
+++ b/packages/frontend/src/components/PlanChooser.tsx
@@ -1,0 +1,42 @@
+import { useContext, useEffect, useState } from 'react';
+import { WorkbenchContext } from '../routes/ClaimWorkbench';
+import { PlanOption } from '../lib/types';
+
+interface Props {
+  onAct: (plan: PlanOption) => void;
+}
+
+export default function PlanChooser({ onAct }: Props) {
+  const { plan } = useContext(WorkbenchContext);
+  const [selected, setSelected] = useState<PlanOption | null>(null);
+
+  useEffect(() => {
+    if (plan && plan.plans.length > 0) {
+      setSelected(plan.plans[0]);
+    }
+  }, [plan]);
+
+  if (!plan) return null;
+
+  return (
+    <div>
+      <h3>Plan</h3>
+      {plan.plans.map((p) => (
+        <label key={p.type} style={{ display: 'block', border: '1px solid #ddd', padding: '8px', marginBottom: '4px' }}>
+          <input type="radio" name="plan" checked={selected?.type === p.type} onChange={() => setSelected(p)} />{' '}
+          <strong>{p.type}</strong> - {p.rationale}
+          <div>
+            {p.actions.map((a, i) => (
+              <span key={i}>
+                {a.addModifier ? `addModifier:${a.addModifier}` : ''}
+                {a.replaceDx ? ` replaceDx:${a.replaceDx}` : ''}
+              </span>
+            ))}
+          </div>
+          {p.citation && <small>{p.citation}</small>}
+        </label>
+      ))}
+      <button onClick={() => selected && onAct(selected)}>Act (⌘/Ctrl+Shift+Enter)</button>
+    </div>
+  );
+}

--- a/packages/frontend/src/index.test.ts
+++ b/packages/frontend/src/index.test.ts
@@ -1,5 +1,0 @@
-import { render } from './index';
-
-test('render returns frontend version', () => {
-  expect(render()).toBe('Frontend 1.0');
-});

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -1,5 +1,0 @@
-import { version } from '@codexia/contracts';
-
-export function render(): string {
-  return `Frontend ${version()}`;
-}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1,0 +1,37 @@
+const BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8000';
+
+async function j<T>(r: Response): Promise<T> {
+  if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+  return (await r.json()) as T;
+}
+
+export async function postAssess(claim: any) {
+  return j(fetch(`${BASE}/v1/assess`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(claim)
+  }));
+}
+
+export async function postPlan(claim: any, assessment: any) {
+  return j(fetch(`${BASE}/v1/plan`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ claim, assessment })
+  }));
+}
+
+export async function postAct(claim: any, plan: any, assessment?: any) {
+  return j(fetch(`${BASE}/v1/act`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ claim, plan, assessment })
+  }));
+}
+
+export async function getBrief(userId: string, date: string) {
+  const u = new URL(`${BASE}/v1/brief`);
+  u.searchParams.set('user_id', userId);
+  u.searchParams.set('date', date);
+  return j(fetch(u.toString()));
+}

--- a/packages/frontend/src/lib/storage.ts
+++ b/packages/frontend/src/lib/storage.ts
@@ -1,0 +1,21 @@
+const KEY = 'recentClaims';
+
+export function list(): any[] {
+  try {
+    return JSON.parse(localStorage.getItem(KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+export function save(claim: any) {
+  const arr = list();
+  const str = JSON.stringify(claim);
+  const filtered = arr.filter((c) => JSON.stringify(c) !== str);
+  filtered.unshift(claim);
+  localStorage.setItem(KEY, JSON.stringify(filtered.slice(0, 5)));
+}
+
+export function get(i: number) {
+  return list()[i];
+}

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -1,0 +1,45 @@
+export interface Claim {
+  [key: string]: any;
+}
+
+export interface AssessmentResult {
+  risk: number;
+  drivers: { issue: string; contribution: number }[];
+  evidence: { source: string; clauseId: string; snippet: string }[];
+}
+
+export interface PlanAction {
+  addModifier?: string;
+  replaceDx?: string;
+}
+
+export interface PlanOption {
+  type: string;
+  rationale: string;
+  actions: PlanAction[];
+  citation?: string;
+}
+
+export interface PlanResult {
+  plans: PlanOption[];
+}
+
+export interface ActResult {
+  artifactType: 'corrected_claim' | 'appeal_letter';
+  correctedClaim?: Claim;
+  appealLetter?: string;
+}
+
+export interface BriefItem {
+  score: number;
+  claim: Claim;
+  why: string;
+  eta: string;
+  delta: number;
+  deadline: string;
+}
+
+export interface BriefResult {
+  highlights: string[];
+  queue: BriefItem[];
+}

--- a/packages/frontend/src/lib/ui.tsx
+++ b/packages/frontend/src/lib/ui.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface Toast {
+  id: number;
+  message: string;
+}
+
+const ToastContext = createContext<(msg: string) => void>(() => {});
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  function push(message: string) {
+    setToasts((t) => [...t, { id: Date.now(), message }]);
+    setTimeout(() => setToasts((t) => t.slice(1)), 3000);
+  }
+
+  return (
+    <ToastContext.Provider value={push}>
+      {children}
+      <div className="fixed bottom-2 right-2 space-y-2">
+        {toasts.map((t) => (
+          <div key={t.id} className="bg-black text-white p-2 rounded">
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { ToastProvider } from './lib/ui';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <ToastProvider>
+      <App />
+    </ToastProvider>
+  </React.StrictMode>
+);

--- a/packages/frontend/src/routes/ClaimWorkbench.tsx
+++ b/packages/frontend/src/routes/ClaimWorkbench.tsx
@@ -1,0 +1,116 @@
+import React, { createContext, useEffect, useMemo, useState } from 'react';
+import ClaimEditor from '../components/ClaimEditor';
+import AssessmentView from '../components/AssessmentView';
+import PlanChooser from '../components/PlanChooser';
+import ArtifactViewer from '../components/ArtifactViewer';
+import { postAssess, postPlan, postAct } from '../lib/api';
+import { save, list } from '../lib/storage';
+import { AssessmentResult, PlanResult, ActResult, PlanOption } from '../lib/types';
+
+interface Ctx {
+  assessment: AssessmentResult | null;
+  plan: PlanResult | null;
+  artifact: ActResult | null;
+  setAssessment: (a: AssessmentResult | null) => void;
+  setPlan: (p: PlanResult | null) => void;
+  setArtifact: (a: ActResult | null) => void;
+}
+
+export const WorkbenchContext = createContext<Ctx>({
+  assessment: null,
+  plan: null,
+  artifact: null,
+  setAssessment: () => {},
+  setPlan: () => {},
+  setArtifact: () => {}
+});
+
+export default function ClaimWorkbench() {
+  const [claimText, setClaimText] = useState('{}');
+  const [assessment, setAssessment] = useState<AssessmentResult | null>(null);
+  const [plan, setPlan] = useState<PlanResult | null>(null);
+  const [artifact, setArtifact] = useState<ActResult | null>(null);
+  const [showRecent, setShowRecent] = useState(false);
+
+  const claim = useMemo(() => {
+    try {
+      return JSON.parse(claimText);
+    } catch {
+      return null;
+    }
+  }, [claimText]);
+
+  async function handleAssess() {
+    if (!claim) return;
+    const res = await postAssess(claim);
+    setAssessment(res);
+    save(claim);
+    setPlan(null);
+    setArtifact(null);
+  }
+
+  async function handlePlan() {
+    if (!claim || !assessment) return;
+    const res = await postPlan(claim, assessment);
+    setPlan(res);
+    setArtifact(null);
+  }
+
+  async function handleAct(p: PlanOption) {
+    if (!claim) return;
+    const res = await postAct(claim, p, assessment);
+    setArtifact(res);
+  }
+
+  useEffect(() => {
+    function key(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleAssess();
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && e.shiftKey) {
+        e.preventDefault();
+        if (plan && plan.plans[0]) handleAct(plan.plans[0]);
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setShowRecent(true);
+      }
+    }
+    window.addEventListener('keydown', key);
+    return () => window.removeEventListener('keydown', key);
+  }, [assessment, plan, claim]);
+
+  return (
+    <WorkbenchContext.Provider value={{ assessment, plan, artifact, setAssessment, setPlan, setArtifact }}>
+      <div className="p-4">
+        {showRecent && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center" onClick={() => setShowRecent(false)}>
+            <div className="bg-white p-4">
+              {list().map((c, i) => (
+                <button
+                  key={i}
+                  onClick={() => {
+                    setClaimText(JSON.stringify(c, null, 2));
+                    setShowRecent(false);
+                  }}
+                  className="block w-full text-left"
+                >
+                  {JSON.stringify(c).slice(0, 60)}...
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+        <div className="grid md:grid-cols-2 gap-4">
+          <ClaimEditor text={claimText} setText={setClaimText} onAssess={handleAssess} />
+          <div className="flex flex-col gap-4">
+            <AssessmentView onPlan={handlePlan} />
+            <PlanChooser onAct={handleAct} />
+            <ArtifactViewer />
+          </div>
+        </div>
+      </div>
+    </WorkbenchContext.Provider>
+  );
+}

--- a/packages/frontend/src/routes/MorningBrief.tsx
+++ b/packages/frontend/src/routes/MorningBrief.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { getBrief } from '../lib/api';
+import { BriefResult, Claim } from '../lib/types';
+import { save } from '../lib/storage';
+import { useNavigate } from 'react-router-dom';
+
+export default function MorningBrief() {
+  const [userId, setUserId] = useState('U1');
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [brief, setBrief] = useState<BriefResult | null>(null);
+  const nav = useNavigate();
+
+  useEffect(() => {
+    getBrief(userId, date).then(setBrief).catch(() => {});
+  }, [userId, date]);
+
+  function openClaim(c: Claim) {
+    save(c);
+    nav('/');
+  }
+
+  return (
+    <div className="p-4">
+      <h2>Morning Brief</h2>
+      <div className="flex gap-2 mb-4">
+        <input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+        <select value={userId} onChange={(e) => setUserId(e.target.value)}>
+          <option value="U1">U1</option>
+          <option value="U2">U2</option>
+        </select>
+      </div>
+      {brief && (
+        <>
+          <h3>Highlights</h3>
+          <ul>
+            {brief.highlights.map((h, i) => (
+              <li key={i}>{h}</li>
+            ))}
+          </ul>
+          <h3>Queue</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Score</th>
+                <th>Claim</th>
+                <th>Why</th>
+                <th>ETA</th>
+                <th>Δ$</th>
+                <th>Deadline</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {brief.queue.map((q, i) => (
+                <tr key={i} style={{ fontWeight: i === 0 ? 'bold' : undefined }}>
+                  <td>{q.score}</td>
+                  <td>{JSON.stringify(q.claim).slice(0, 20)}...</td>
+                  <td>{q.why}</td>
+                  <td>{q.eta}</td>
+                  <td>{q.delta}</td>
+                  <td>{q.deadline}</td>
+                  <td>
+                    <button onClick={() => openClaim(q.claim)}>Open in Workbench</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/tests/api.spec.ts
+++ b/packages/frontend/tests/api.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { postAssess, postPlan, postAct, getBrief } from '../src/lib/api';
+
+function mock(body: any) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body
+  } as Response);
+}
+
+describe('api', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  it('postAssess', async () => {
+    (fetch as any).mockImplementation(() => mock({ risk: 0.1 }));
+    const res = await postAssess({ a: 1 });
+    expect(res).toEqual({ risk: 0.1 });
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/v1/assess',
+      expect.objectContaining({ method: 'POST', headers: { 'content-type': 'application/json' } })
+    );
+  });
+
+  it('postPlan', async () => {
+    (fetch as any).mockImplementation(() => mock({ plans: [] }));
+    const res = await postPlan({}, {});
+    expect(res).toEqual({ plans: [] });
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/v1/plan',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('postAct', async () => {
+    (fetch as any).mockImplementation(() => mock({ artifactType: 'corrected_claim' }));
+    const res = await postAct({}, {});
+    expect(res).toEqual({ artifactType: 'corrected_claim' });
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/v1/act',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('getBrief', async () => {
+    (fetch as any).mockImplementation(() => mock({ highlights: [], queue: [] }));
+    const res = await getBrief('u', '2020-01-01');
+    expect(res).toEqual({ highlights: [], queue: [] });
+    expect(fetch).toHaveBeenCalledWith('http://localhost:8000/v1/brief?user_id=u&date=2020-01-01');
+  });
+});

--- a/packages/frontend/tests/workbench.spec.tsx
+++ b/packages/frontend/tests/workbench.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ClaimWorkbench from '../src/routes/ClaimWorkbench';
+import { vi } from 'vitest';
+
+vi.mock('../src/lib/api', () => ({
+  postAssess: vi.fn(async () => ({
+    risk: 0.7,
+    drivers: [{ issue: 'mismatch', contribution: 0.5 }],
+    evidence: [{ source: 's', clauseId: 'c1', snippet: 'evidence' }]
+  })),
+  postPlan: vi.fn(async () => ({
+    plans: [
+      { type: 'Recoding', rationale: 'Add 59', actions: [{ addModifier: '59' }] },
+      { type: 'Appeal', rationale: 'Appeal', actions: [] }
+    ]
+  })),
+  postAct: vi.fn(async () => ({
+    artifactType: 'corrected_claim',
+    correctedClaim: { lines: [{ modifiers: ['-59'] }] }
+  }))
+}));
+
+const mockClaim = { lines: [{ modifiers: [] }] };
+
+test('workbench flow', async () => {
+  render(<ClaimWorkbench />);
+  const textarea = screen.getByRole('textbox');
+  fireEvent.change(textarea, { target: { value: JSON.stringify(mockClaim) } });
+
+  fireEvent.click(screen.getByText(/Assess/));
+  await screen.findByText(/Risk/);
+  expect(screen.getByText('mismatch')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Plan'));
+  await screen.findByText('Recoding');
+  await screen.findByText('Appeal');
+
+  fireEvent.click(screen.getByText(/Act/));
+  await screen.findByText((content) => content.includes('-59'));
+});

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,18 +1,20 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "composite": true
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ],
-  "references": [
-    {
-      "path": "../contracts"
-    }
-  ],
-  "exclude": [
-    "src/**/*.test.ts"
-  ]
+  "include": ["src", "tests", "vite.config.ts"]
 }

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173 },
+  test: { environment: 'jsdom', globals: true }
+});


### PR DESCRIPTION
## Summary
- scaffold React + Vite frontend with workbench and morning brief routes
- add typed API client, localStorage helpers, and basic UI components
- include vitest tests for API wrapper and workbench flow

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2freact)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbea1e6cd88322901c12461d6032cf