### PR TITLE
feat: add MV3 extension sidebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test:
 	# TS tests (optional; won't fail if absent)
 	[ -d packages/frontend ] && (cd packages/frontend && npm test --silent) || true
 	[ -d packages/contracts ] && (cd packages/contracts && npm test --silent) || true
+	[ -d packages/extension ] && (cd packages/extension && npm test --silent) || true
 
 build:
 	docker compose -f infra/docker-compose.yml build

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -1,0 +1,24 @@
+# Codexia Sidebar Extension
+
+## Build
+
+```bash
+npm run build
+```
+
+## Load in Chrome
+
+1. Go to `chrome://extensions`.
+2. Enable **Developer Mode**.
+3. Click **Load Unpacked** and select `packages/extension/dist`.
+
+Note: To keep PRs text-only, icons are omitted. After merging, you can add PNG icons (16/32/48/128) to `packages/extension/public/` and re-build. Chrome will load without icons.
+
+## Demo
+
+Open `packages/extension/public/demo/mock.html` in Chrome (drag into a tab or serve via `file://`). Click the toolbar icon to toggle the sidebar. Use **Assess → Plan → Apply Fix** to exercise the flow.
+
+## Troubleshooting
+
+* Set `VITE_API_BASE` if backend is on another host.
+* Ensure the backend allows CORS from the extension.

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,0 +1,15 @@
+{
+  "manifest_version": 3,
+  "name": "Codexia Sidebar",
+  "version": "0.1.0",
+  "description": "Ambient RCM Copilot: assess, plan, and act on claims in-page.",
+  "action": { "default_title": "Codexia Sidebar" },
+  "background": { "service_worker": "background.js" },
+  "content_scripts": [{
+    "matches": ["<all_urls>"],
+    "js": ["content.js"],
+    "run_at": "document_idle"
+  }],
+  "permissions": [],
+  "host_permissions": ["http://localhost:8000/*", "http://127.0.0.1:8000/*"]
+}

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,10 +1,27 @@
 {
-  "name": "@codexia/extension",
-  "version": "1.0.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "license": "MIT",
+  "name": "codexia-extension",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite build --watch",
+    "build": "vite build",
+    "lint": "eslint --ext .ts,.tsx src",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --environment jsdom"
+  },
   "dependencies": {
-    "@codexia/contracts": "1.0.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2",
+    "vitest": "^2.0.5",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^9.9.0",
+    "@types/chrome": "^0.0.268"
   }
 }

--- a/packages/extension/public/demo/mock.html
+++ b/packages/extension/public/demo/mock.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Codexia Demo Mock</title></head>
+<body>
+  <h1>Claim Portal — Patient 123</h1>
+  <p>Below is a JSON block representing the claim currently in view.</p>
+  <script id="codexia-claim" type="application/json">
+  {
+    "claimId": "CLM-1001",
+    "payer": {"name":"UnitedHealthcare","planId":"UHC-GOLD-CA","state":"CA"},
+    "patient": {"dob":"1962-05-14","age":63,"sex":"F"},
+    "provider": {"npi":"1093817465","siteOfService":"11"},
+    "lines": [
+      {"cpt":"97012","dx":["M25.50"],"modifiers":[""],"units":1,"charge":180.0},
+      {"cpt":"97110","dx":["M25.50"],"modifiers":[""],"units":1,"charge":190.0}
+    ],
+    "attachments":[{"type":"progress_note","id":"doc_123"}],
+    "history":[{"ts":"2025-09-05T10:00:00Z","event":"created"}],
+    "notes":["Therapeutic exercise same session; distinct procedural service not indicated in line 1."]
+  }
+  </script>
+  <p>Load the extension as Unpacked and click the toolbar icon to toggle the sidebar.</p>
+</body>
+</html>

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -1,0 +1,3 @@
+chrome.action.onClicked.addListener((tab) => {
+  if (tab.id) chrome.tabs.sendMessage(tab.id, { type: "TOGGLE_SIDEBAR" });
+});

--- a/packages/extension/src/content.ts
+++ b/packages/extension/src/content.ts
@@ -1,0 +1,6 @@
+import { mountSidebar } from "./ui/mountSidebar";
+(function bootstrap() {
+  const DEMO_FLAG = document.querySelector("#codexia-claim");
+  if (DEMO_FLAG) mountSidebar();
+  chrome.runtime.onMessage?.addListener((msg) => { if (msg?.type === "TOGGLE_SIDEBAR") mountSidebar(); });
+})();

--- a/packages/extension/src/index.test.ts
+++ b/packages/extension/src/index.test.ts
@@ -1,5 +1,0 @@
-import { show } from './index';
-
-test('show returns extension version', () => {
-  expect(show()).toBe('Extension 1.0');
-});

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -1,5 +1,0 @@
-import { version } from '@codexia/contracts';
-
-export function show(): string {
-  return `Extension ${version()}`;
-}

--- a/packages/extension/src/lib/api.ts
+++ b/packages/extension/src/lib/api.ts
@@ -1,0 +1,5 @@
+const BASE = (globalThis as any).VITE_API_BASE || "http://localhost:8000";
+async function j<T>(r: Response): Promise<T> { if (!r.ok) throw new Error(`${r.status} ${r.statusText}`); return r.json() as Promise<T>; }
+export async function postAssess(claim: any){ return j(fetch(`${BASE}/v1/assess`, {method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(claim)})); }
+export async function postPlan(claim: any, assessment: any){ return j(fetch(`${BASE}/v1/plan`, {method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({claim,assessment})})); }
+export async function postAct(claim: any, plan: any, assessment?: any){ return j(fetch(`${BASE}/v1/act`, {method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({claim,plan,assessment})})); }

--- a/packages/extension/src/lib/extract.ts
+++ b/packages/extension/src/lib/extract.ts
@@ -1,0 +1,11 @@
+export function extractClaimFromDom(doc: Document = document): any | null {
+  const script = doc.querySelector('script#codexia-claim[type="application/json"]') as HTMLScriptElement | null;
+  if (script?.textContent) {
+    try { return JSON.parse(script.textContent); } catch { /* fallthrough */ }
+  }
+  const pre = doc.querySelector('pre#codexia-claim');
+  if (pre?.textContent) {
+    try { return JSON.parse(pre.textContent); } catch { /* fallthrough */ }
+  }
+  return null;
+}

--- a/packages/extension/src/lib/types.ts
+++ b/packages/extension/src/lib/types.ts
@@ -1,0 +1,34 @@
+export interface AssessmentDriver {
+  label: string;
+  weight?: number;
+}
+
+export interface Evidence {
+  source: string;
+  clause_id: string;
+}
+
+export interface AssessmentResult {
+  risk: number;
+  drivers: AssessmentDriver[];
+  evidence: Evidence[];
+}
+
+export interface PlanAction {
+  [key: string]: any;
+}
+
+export interface PlanOption {
+  type: string;
+  actions: PlanAction[];
+  rationale: string;
+}
+
+export interface PlanResult {
+  plans: PlanOption[];
+}
+
+export interface ActResult {
+  artifactType: string;
+  payload: any;
+}

--- a/packages/extension/src/ui/Sidebar.tsx
+++ b/packages/extension/src/ui/Sidebar.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { extractClaimFromDom } from '../lib/extract';
+import { postAssess, postPlan, postAct } from '../lib/api';
+import { AssessmentResult, PlanResult, ActResult } from '../lib/types';
+import './styles.css';
+
+export const Sidebar: React.FC = () => {
+  const [claim, setClaim] = useState<any | null>(() => extractClaimFromDom());
+  const [pasted, setPasted] = useState('');
+  const [assessment, setAssessment] = useState<AssessmentResult | null>(null);
+  const [plan, setPlan] = useState<PlanResult | null>(null);
+  const [act, setAct] = useState<ActResult | null>(null);
+
+  const usePasted = () => {
+    try { setClaim(JSON.parse(pasted)); } catch { alert('Invalid JSON'); }
+  };
+
+  const handleAssess = async () => {
+    if (!claim) return;
+    const res = await postAssess(claim);
+    setAssessment(res);
+  };
+
+  const handlePlan = async () => {
+    if (!claim || !assessment) return;
+    const res = await postPlan(claim, assessment);
+    setPlan(res);
+  };
+
+  const handleAct = async () => {
+    if (!claim || !plan) return;
+    const res = await postAct(claim, plan.plans[0], assessment);
+    setAct(res);
+  };
+
+  return (
+    <div className="codexia-sidebar">
+      <div className="codexia-card">
+        <h3>Claim</h3>
+        {claim ? <div>Extracted ✓</div> : (
+          <>
+            <textarea value={pasted} onChange={e => setPasted(e.target.value)} />
+            <button onClick={usePasted}>Use Pasted</button>
+          </>
+        )}
+      </div>
+
+      <div className="codexia-card">
+        <h3>Assessment</h3>
+        {!assessment && <button disabled={!claim} onClick={handleAssess}>Assess</button>}
+        {assessment && (
+          <>
+            <div>Risk: {assessment.risk.toFixed(2)}</div>
+            <div className="bar"><div className="bar-fill" style={{ width: `${assessment.risk * 100}%` }}></div></div>
+            <div>
+              {assessment.drivers.map((d, i) => (
+                <span key={i} className="badge">{d.label}</span>
+              ))}
+            </div>
+            <ul>
+              {assessment.evidence.map((e, i) => (
+                <li key={i}>{e.source} · {e.clause_id}</li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+
+      <div className="codexia-card">
+        <h3>Plan / Act</h3>
+        {!plan && <button disabled={!assessment} onClick={handlePlan}>Plan</button>}
+        {plan && !act && (
+          <>
+            <ul>
+              {plan.plans.map((p, i) => (
+                <li key={i}>{p.type}</li>
+              ))}
+            </ul>
+            <button onClick={handleAct}>Apply Fix</button>
+          </>
+        )}
+        {act && (
+          <>
+            {act.artifactType === 'corrected_claim' && (
+              <>
+                <pre>{JSON.stringify(act.payload, null, 2)}</pre>
+                <a href={URL.createObjectURL(new Blob([JSON.stringify(act.payload, null, 2)], { type: 'application/json' }))} download="claim.json">Download JSON</a>
+              </>
+            )}
+            {act.artifactType === 'appeal_markdown' && (
+              <>
+                <pre>{String(act.payload)}</pre>
+                <a href={URL.createObjectURL(new Blob([String(act.payload)], { type: 'text/markdown' }))} download="appeal.md">Download .md</a>
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/packages/extension/src/ui/mountSidebar.tsx
+++ b/packages/extension/src/ui/mountSidebar.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import Sidebar from './Sidebar';
+
+export function mountSidebar() {
+  const existing = document.getElementById('codexia-sidebar-root');
+  if (existing) {
+    existing.remove();
+    return;
+  }
+  const div = document.createElement('div');
+  div.id = 'codexia-sidebar-root';
+  document.body.appendChild(div);
+  const root = createRoot(div);
+  root.render(<Sidebar />);
+}

--- a/packages/extension/src/ui/styles.css
+++ b/packages/extension/src/ui/styles.css
@@ -1,0 +1,25 @@
+#codexia-sidebar-root {
+  all: initial;
+}
+
+.codexia-sidebar {
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 380px;
+  height: 100vh;
+  box-shadow: -2px 0 4px rgba(0,0,0,0.1);
+  background: #fff;
+  border-left: 1px solid #ddd;
+  z-index: 2147483647;
+  font-family: system-ui, sans-serif;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.codexia-card { border: 1px solid #ccc; padding: 8px; margin-bottom: 8px; border-radius: 4px; }
+button { padding: 4px 8px; margin-top: 4px; }
+textarea { width: 100%; min-height: 120px; }
+.badge { display: inline-block; padding: 2px 4px; background: #eee; border-radius: 4px; margin: 2px; }
+.bar { width: 100%; background: #eee; height: 8px; border-radius: 4px; overflow: hidden; }
+.bar-fill { height: 100%; background: #0a0; }

--- a/packages/extension/tests/extract.spec.ts
+++ b/packages/extension/tests/extract.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { extractClaimFromDom } from '../src/lib/extract';
+
+describe('extractClaimFromDom', () => {
+  it('returns claim from script tag', () => {
+    const html = '<script id="codexia-claim" type="application/json">{"claimId":"CLM-1"}</script>';
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const claim = extractClaimFromDom(doc);
+    expect(claim?.claimId).toBe('CLM-1');
+  });
+
+  it('returns null on invalid JSON', () => {
+    const html = '<script id="codexia-claim" type="application/json">{bad json}</script>';
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const claim = extractClaimFromDom(doc);
+    expect(claim).toBeNull();
+  });
+});

--- a/packages/extension/tests/sidebar.spec.tsx
+++ b/packages/extension/tests/sidebar.spec.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Sidebar from '../src/ui/Sidebar';
+
+const assessRes = { risk: 0.72, drivers: [{ label: 'upcoding' }], evidence: [{ source: 'policy', clause_id: '123' }] };
+const planRes = { plans: [ { type: 'recoding', actions: [{ line: 0, addModifier: '59' }], rationale: '...' }, { type: 'appeal', actions: [] } ] };
+const actRes = { artifactType: 'corrected_claim', payload: { lines: [ { modifiers: ['59'] } ] } };
+
+beforeEach(() => {
+  document.body.innerHTML = '<script id="codexia-claim" type="application/json">{"id":"X"}</script>';
+  vi.spyOn(globalThis, 'fetch').mockImplementation((input: RequestInfo) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.endsWith('/v1/assess')) return Promise.resolve(new Response(JSON.stringify(assessRes)));
+    if (url.endsWith('/v1/plan')) return Promise.resolve(new Response(JSON.stringify(planRes)));
+    if (url.endsWith('/v1/act')) return Promise.resolve(new Response(JSON.stringify(actRes)));
+    return Promise.reject(new Error('unknown url'));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Sidebar', () => {
+  it('assess plan act flow', async () => {
+    const user = userEvent.setup();
+    render(<Sidebar />);
+
+    await user.click(screen.getByText('Assess'));
+    await screen.findByText(/Risk/);
+    expect(screen.getByText('upcoding')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Plan'));
+    await user.click(screen.getByText('Apply Fix'));
+    await screen.findByText(/"59"/);
+  });
+});

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -1,18 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "outDir": "dist",
-    "composite": true
+    "rootDir": "src",
+    "types": ["chrome"]
   },
-  "include": [
-    "src"
-  ],
-  "references": [
-    {
-      "path": "../contracts"
-    }
-  ],
-  "exclude": [
-    "src/**/*.test.ts"
-  ]
+  "include": ["src", "tests"],
+  "references": []
 }

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite';
+import { copyFileSync } from 'node:fs';
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        background: 'src/background.ts',
+        content: 'src/content.ts'
+      },
+      output: {
+        entryFileNames: '[name].js'
+      }
+    },
+    outDir: 'dist',
+    emptyOutDir: true
+  },
+  plugins: [
+    {
+      name: 'copy-manifest',
+      writeBundle() {
+        copyFileSync('manifest.json', 'dist/manifest.json');
+      }
+    }
+  ]
+});


### PR DESCRIPTION
## Summary
- scaffold Chromiun MV3 extension with React sidebar and DOM claim extraction
- wire assess -> plan -> act API flow and basic UI styling
- add vitest unit tests and hook extension into make test
- remove binary icons to keep PR text-only and document optional icons

## Testing
- `npm test -w packages/extension` *(fails: vitest: not found)*
- `npm run build -w packages/extension` *(fails: vite: not found)*
- `make test` *(fails: ModuleNotFoundError: No module named 'packages'; vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbec5488ec83229029b2f24f21260d