### PR TITLE
feat: add security hardening middleware and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ Common tooling is configured at the root:
 - **Docker**: `docker build -t codexia .`
 
 Continuous integration runs these commands via GitHub Actions.
+
+## Ops/Security
+
+The backend sets strict headers on every response:
+`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` and `Cache-Control`.
+Enable `Strict-Transport-Security` by setting `ENABLE_HSTS=true` **only** when serving behind TLS.
+
+Payload and rate limits are configurable via environment variables such as
+`MAX_PAYLOAD_BYTES` and `RATE_LIMIT_RPS`. Metrics are exposed in Prometheus
+format at `/metrics` and include request counts, latencies and rate-limit drops.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -4,6 +4,23 @@ services:
     ports: ["8000:8000"]
     environment:
       - PORT=8000
+      - LOG_LEVEL=INFO
+      - MAX_PAYLOAD_BYTES=1500000
+      - RATE_LIMIT_RPS=5
+      - ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+      - ENABLE_HSTS=false
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/readyz"]
+      interval: 10s
+      timeout: 2s
+      retries: 5
+      start_period: 5s
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+    restart: unless-stopped
   console:
     build: ./packages/frontend
     ports: ["5173:5173"]

--- a/packages/backend/core/config.py
+++ b/packages/backend/core/config.py
@@ -9,7 +9,12 @@ class Settings(BaseSettings):
     EMBEDDING_MODEL: str = "all-MiniLM-L6-v2"
     VECTOR_PATH: str = "./var/vector"
     AUDIT_PATH: str = "./var/audit"
+    MAX_PAYLOAD_BYTES: int = 1_500_000
+    RATE_LIMIT_RPS: float = 5.0
+    ALLOWED_ORIGINS: str = "http://localhost:5173,http://127.0.0.1:5173"
+    ENABLE_HSTS: bool = False
     LOG_LEVEL: str = "INFO"
+    METRICS_NAMESPACE: str = "codexia"
     RAG_TOPK_DEFAULT: int = 5
     W_DELTA: float = 0.5
     W_FEAS: float = 0.25
@@ -26,3 +31,7 @@ class Settings(BaseSettings):
     def model_post_init(self, __context):
         os.makedirs(self.VECTOR_PATH, exist_ok=True)
         os.makedirs(self.AUDIT_PATH, exist_ok=True)
+
+    @property
+    def allowed_origins(self) -> list[str]:
+        return [o.strip() for o in self.ALLOWED_ORIGINS.split(",") if o.strip()]

--- a/packages/backend/core/logging.py
+++ b/packages/backend/core/logging.py
@@ -1,16 +1,20 @@
 import logging
 import re
+import time
 from datetime import datetime
 from pythonjsonlogger import jsonlogger
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
 from .config import Settings
+from .metrics import record_request
 
-EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
-NPI_RE = re.compile(r"\b\d{10}\b")
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+NPI_RE = re.compile(r"(?<!\d)\d{10}(?!\d)")
 
 
 def redact(text: str) -> str:
-    text = EMAIL_RE.sub("[redacted-email]", text)
-    text = NPI_RE.sub("[redacted-npi]", text)
+    text = EMAIL_RE.sub("[REDACTED_EMAIL]", text)
+    text = NPI_RE.sub("[REDACTED_NPI]", text)
     return text
 
 
@@ -21,7 +25,16 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
         log_record.setdefault("level", record.levelname)
         if "message" in log_record:
             log_record["msg"] = redact(log_record.pop("message"))
-        for field in ["path", "method", "status", "dur_ms", "req_id"]:
+        for field in [
+            "path",
+            "method",
+            "status",
+            "dur_ms",
+            "bytes_in",
+            "bytes_out",
+            "req_id",
+            "client_ip",
+        ]:
             log_record.setdefault(field, None)
 
 
@@ -34,3 +47,36 @@ def configure() -> None:
     root.handlers.clear()
     root.addHandler(handler)
     root.setLevel(getattr(logging, settings.LOG_LEVEL, "INFO"))
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app):
+        super().__init__(app)
+        self.logger = logging.getLogger("codexia")
+
+    async def dispatch(self, request: Request, call_next):
+        body = await request.body()
+        request._body = body
+        start = time.monotonic()
+        response = await call_next(request)
+        dur_ms = int((time.monotonic() - start) * 1000)
+        request_id = getattr(request.state, "request_id", "")
+        bytes_in = getattr(request.state, "bytes_in", len(body))
+        msg = body.decode("utf-8", errors="ignore") if body else ""
+        bytes_out = len(getattr(response, "body", b""))
+        client_ip = request.client.host if request.client else ""
+        self.logger.info(
+            msg,
+            extra={
+                "method": request.method,
+                "path": request.url.path,
+                "status": response.status_code,
+                "dur_ms": dur_ms,
+                "bytes_in": bytes_in,
+                "bytes_out": bytes_out,
+                "req_id": request_id,
+                "client_ip": client_ip,
+            },
+        )
+        record_request(request.method, request.url.path, response.status_code, dur_ms / 1000.0)
+        return response

--- a/packages/backend/core/metrics.py
+++ b/packages/backend/core/metrics.py
@@ -1,0 +1,32 @@
+from prometheus_client import Counter, Histogram
+from .config import Settings
+
+_settings = Settings()
+
+REQUESTS_TOTAL = Counter(
+    f"{_settings.METRICS_NAMESPACE}_requests_total",
+    "Total HTTP requests",
+    ["method", "path", "status"],
+)
+
+REQUEST_LATENCY = Histogram(
+    f"{_settings.METRICS_NAMESPACE}_request_latency_seconds",
+    "HTTP request latency, in seconds",
+    ["method", "path"],
+    buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2],
+)
+
+RATE_LIMIT_DROPPED = Counter(
+    f"{_settings.METRICS_NAMESPACE}_rate_limit_dropped_total",
+    "Requests dropped due to rate limiting",
+    ["path"],
+)
+
+
+def record_request(method: str, path: str, status: int, dur_s: float) -> None:
+    REQUESTS_TOTAL.labels(method=method, path=path, status=str(status)).inc()
+    REQUEST_LATENCY.labels(method=method, path=path).observe(dur_s)
+
+
+def inc_rate_limited(path: str) -> None:
+    RATE_LIMIT_DROPPED.labels(path=path).inc()

--- a/packages/backend/core/security.py
+++ b/packages/backend/core/security.py
@@ -1,25 +1,72 @@
 import time
+from math import ceil
 from uuid import uuid4
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+from .config import Settings
+from .metrics import inc_rate_limited
+
+
+class TokenBucket:
+    def __init__(self, rate: float):
+        self.rate = rate
+        self.capacity = ceil(3 * rate)
+        self.tokens = {}
+
+    def allow(self, key: str) -> bool:
+        now = time.monotonic()
+        tokens, last = self.tokens.get(key, (self.capacity, now))
+        tokens = min(self.capacity, tokens + (now - last) * self.rate)
+        if tokens < 1:
+            self.tokens[key] = (tokens, now)
+            return False
+        self.tokens[key] = (tokens - 1, now)
+        return True
 
 
 class SecurityMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app, max_body_size: int = int(1.5 * 1024 * 1024)):
+    def __init__(self, app):
         super().__init__(app)
-        self.max_body_size = max_body_size
+        settings = Settings()
+        self.max_body_size = settings.MAX_PAYLOAD_BYTES
+        self.enable_hsts = settings.ENABLE_HSTS
+        self.bucket = TokenBucket(settings.RATE_LIMIT_RPS)
 
     async def dispatch(self, request: Request, call_next):
         request_id = request.headers.get("X-Request-Id") or str(uuid4())
-        start = time.time()
         body = await request.body()
         if len(body) > self.max_body_size:
+            request.state.request_id = request_id
+            request.state.bytes_in = len(body)
             return Response(status_code=413)
-        request._body = body  # allow downstream to read again
+        request._body = body
         request.state.request_id = request_id
+        request.state.bytes_in = len(body)
+        client_ip = request.client.host if request.client else "unknown"
+        if not self.bucket.allow(client_ip):
+            inc_rate_limited(request.url.path)
+            headers = {"Retry-After": "1", "X-Request-Id": request_id}
+            return Response(status_code=429, headers=headers)
         response = await call_next(request)
-        duration = int((time.time() - start) * 1000)
         response.headers.setdefault("X-Request-Id", request_id)
-        response.headers.setdefault("X-Response-Time", str(duration))
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        response.headers.setdefault("Cache-Control", "no-store")
+        if self.enable_hsts:
+            response.headers.setdefault(
+                "Strict-Transport-Security",
+                "max-age=31536000; includeSubDomains",
+            )
         return response
+
+
+def cors_config() -> dict:
+    s = Settings()
+    return {
+        "allow_origins": s.allowed_origins,
+        "allow_credentials": True,
+        "allow_methods": ["*"],
+        "allow_headers": ["*"],
+    }

--- a/packages/backend/routers/health.py
+++ b/packages/backend/routers/health.py
@@ -1,9 +1,35 @@
-from fastapi import APIRouter
 import os
+import time
+import json
+from fastapi import APIRouter, Response, status
+from ..core.config import Settings
 
 router = APIRouter(tags=["ops"])
+_START = time.time()
+settings = Settings()
 
 
 @router.get("/healthz")
 def healthz():
-    return {"status": "ok", "gitSha": os.getenv("GIT_SHA", "unknown")}
+    uptime = time.time() - _START
+    return {
+        "status": "ok",
+        "gitSha": os.getenv("GIT_SHA", "unknown"),
+        "version": os.getenv("APP_VERSION", "0.1.0"),
+        "uptime_s": uptime,
+    }
+
+
+@router.get("/readyz")
+def readyz():
+    errors = []
+    if settings.VECTOR_PATH and not os.path.isdir(settings.VECTOR_PATH):
+        errors.append("vector path missing")
+    if not os.access(settings.AUDIT_PATH, os.W_OK):
+        errors.append("audit path not writable")
+    ready = not errors
+    status_code = status.HTTP_200_OK if ready else status.HTTP_503_SERVICE_UNAVAILABLE
+    body = {"ready": ready}
+    if errors:
+        body["errors"] = errors
+    return Response(status_code=status_code, media_type="application/json", content=json.dumps(body))

--- a/packages/backend/tests/test_metrics_labels.py
+++ b/packages/backend/tests/test_metrics_labels.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+from packages.backend.app import get_app
+from packages.backend.routers import assess as assess_router
+
+CLAIM = {
+    "claimId": "C1",
+    "payer": {"name": "p"},
+    "patient": {"dob": "2000-01-01", "age": 1, "sex": "M"},
+    "provider": {"npi": "1234567890"},
+    "lines": [{"cpt": "A", "dx": ["B"], "modifiers": [], "units": 1, "charge": 1.0}],
+}
+
+
+def create_client(monkeypatch):
+    monkeypatch.setattr(assess_router, "assess_claim", lambda *a, **k: {"risk": 0, "drivers": [], "evidence": []})
+    return TestClient(get_app())
+
+
+def test_metrics_labels(monkeypatch):
+    c = create_client(monkeypatch)
+    c.get("/healthz")
+    c.post("/v1/assess", json=CLAIM)
+    c.post("/v1/assess", json=CLAIM)
+    metrics = c.get("/metrics").text
+    assert 'codexia_requests_total{method="GET",path="/healthz",status="200"}' in metrics
+    assert 'codexia_requests_total{method="POST",path="/v1/assess",status="200"}' in metrics
+    assert 'codexia_request_latency_seconds_bucket{le="0.01",method="POST",path="/v1/assess"}' in metrics

--- a/packages/backend/tests/test_payload_limit.py
+++ b/packages/backend/tests/test_payload_limit.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient
+from packages.backend.app import get_app
+from packages.backend.routers import assess as assess_router
+
+BASE_CLAIM = {
+    "claimId": "C1",
+    "payer": {"name": "p"},
+    "patient": {"dob": "2000-01-01", "age": 1, "sex": "M"},
+    "provider": {"npi": "1234567890"},
+    "lines": [{"cpt": "A", "dx": ["B"], "modifiers": [], "units": 1, "charge": 1.0}],
+}
+
+
+def create_client(monkeypatch, **env):
+    for k, v in env.items():
+        monkeypatch.setenv(k, str(v))
+    monkeypatch.setattr(assess_router, "assess_claim", lambda *a, **k: {"risk": 0, "drivers": [], "evidence": []})
+    return TestClient(get_app())
+
+
+def test_payload_limit(monkeypatch):
+    big_claim = dict(BASE_CLAIM)
+    big_claim["notes"] = ["x" * 2048]
+    c = create_client(monkeypatch, MAX_PAYLOAD_BYTES=1024)
+    r = c.post("/v1/assess", json=big_claim)
+    assert r.status_code == 413
+    r = c.post("/v1/assess", json=BASE_CLAIM)
+    assert r.status_code == 200

--- a/packages/backend/tests/test_redaction_and_logs.py
+++ b/packages/backend/tests/test_redaction_and_logs.py
@@ -1,0 +1,42 @@
+import logging
+from fastapi.testclient import TestClient
+from packages.backend.app import get_app
+from packages.backend.routers import assess as assess_router
+
+CLAIM = {
+    "claimId": "C1",
+    "payer": {"name": "p"},
+    "patient": {"dob": "2000-01-01", "age": 1, "sex": "M"},
+    "provider": {"npi": "1234567890"},
+    "lines": [{"cpt": "A", "dx": ["B"], "modifiers": [], "units": 1, "charge": 1.0}],
+}
+
+
+def create_client(monkeypatch):
+    monkeypatch.setattr(assess_router, "assess_claim", lambda *a, **k: {"risk": 0, "drivers": [], "evidence": []})
+    client = TestClient(get_app())
+    root = logging.getLogger()
+    records: list[str] = []
+
+    class ListHandler(logging.Handler):
+        def emit(self, record):
+            records.append(self.format(record))
+
+    handler = ListHandler()
+    handler.setFormatter(root.handlers[0].formatter)
+    root.addHandler(handler)
+    return client, records
+
+
+def test_redaction_and_logs(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+    c, records = create_client(monkeypatch)
+    claim = dict(CLAIM)
+    claim["notes"] = ["contact test@example.com"]
+    r = c.post("/v1/assess", json=claim)
+    assert r.status_code == 200
+    joined = "\n".join(records)
+    assert "[REDACTED_EMAIL]" in joined
+    assert "[REDACTED_NPI]" in joined
+    assert "test@example.com" not in joined
+    assert "1234567890" not in joined

--- a/packages/backend/tests/test_security_headers.py
+++ b/packages/backend/tests/test_security_headers.py
@@ -1,0 +1,36 @@
+import os
+from fastapi.testclient import TestClient
+from packages.backend.app import get_app
+from packages.backend.routers import assess as assess_router
+
+CLAIM = {
+    "claimId": "C1",
+    "payer": {"name": "p"},
+    "patient": {"dob": "2000-01-01", "age": 1, "sex": "M"},
+    "provider": {"npi": "1234567890"},
+    "lines": [{"cpt": "A", "dx": ["B"], "modifiers": [], "units": 1, "charge": 1.0}],
+}
+
+
+def create_client(monkeypatch, **env):
+    for k, v in env.items():
+        monkeypatch.setenv(k, str(v))
+    monkeypatch.setattr(assess_router, "assess_claim", lambda *a, **k: {"risk": 0, "drivers": [], "evidence": []})
+    return TestClient(get_app())
+
+
+def test_security_headers(monkeypatch):
+    c = create_client(monkeypatch)
+    r = c.get("/healthz")
+    for h in ["X-Content-Type-Options", "X-Frame-Options", "Referrer-Policy", "Cache-Control"]:
+        assert h in r.headers
+    assert "Strict-Transport-Security" not in r.headers
+    r = c.post("/v1/assess", json=CLAIM)
+    for h in ["X-Content-Type-Options", "X-Frame-Options", "Referrer-Policy", "Cache-Control"]:
+        assert h in r.headers
+    assert r.status_code == 200
+
+    monkeypatch.setenv("ENABLE_HSTS", "true")
+    c = create_client(monkeypatch)
+    r = c.get("/healthz")
+    assert "Strict-Transport-Security" in r.headers


### PR DESCRIPTION
## Summary
- enforce payload size limits, rate limiting, and security headers
- add JSON request logging with PII redaction and Prometheus metrics
- wire healthchecks and ops settings into docker compose

## Testing
- `PYTHONPATH=. pytest -q packages/backend/tests/test_security_headers.py packages/backend/tests/test_payload_limit.py packages/backend/tests/test_redaction_and_logs.py packages/backend/tests/test_metrics_labels.py`
- `docker compose -f infra/docker-compose.yml up -d` *(fails: command not found)*
- `curl -s localhost:8000/readyz` *(no response, service not running)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf9a52b508322a3c90da7bbf0873f