### PR TITLE
Add demo runbook and reset script

### DIFF
--- a/DEMO_RUNBOOK.md
+++ b/DEMO_RUNBOOK.md
@@ -1,0 +1,55 @@
+# Codexia Demo Runbook
+
+## Narrative (8–10 min flow)
+1. **Morning Brief** – open the dashboard and pick a claim.
+2. **Assess** – run `/v1/assess` to get drivers and citations.
+3. **Plan** – invoke `/v1/plan` for recoding or appeal strategy.
+4. **Act** – call `/v1/act` to produce the corrected claim or appeal letter and write an audit entry.
+5. **Sidebar** – show the extension at `public/demo/mock.html`.
+6. **Close** – emphasize faster claims, compliance, and audit trail.
+
+## Preflight Steps
+- Verify Python and Node versions: `python3 --version` and `node --version`.
+- Install deps: `make bootstrap`.
+- Build vector index: `python -m packages.backend.rag.indexer` or run reset script below.
+- Start services:
+  - Backend: `cd packages/backend && uvicorn main:app --reload`.
+  - Frontend: `cd packages/frontend && npm start`.
+  - Extension: load Unpacked in Chrome.
+
+## Reset Script
+```bash
+./scripts/reset_demo.sh
+```
+
+## Live Commands
+```bash
+# Health check
+curl -s localhost:8000/healthz | jq
+
+# Assess
+curl -s -X POST localhost:8000/v1/assess -d '{"claim_id":1}' | jq
+
+# Plan
+curl -s -X POST localhost:8000/v1/plan -d '{"claim_id":1}' | jq
+
+# Act
+curl -s -X POST localhost:8000/v1/act -d '{"claim_id":1}' | jq
+```
+
+## Fallback Playbook
+- Backend down → restart uvicorn.
+- Empty citations → rerun reset script.
+- CORS error → check `ALLOWED_ORIGINS`.
+- 429 rate limit → raise `RATE_LIMIT_RPS`.
+- Extension not mounting → reload Unpacked and open `mock.html`.
+- Audit missing → confirm Act was called.
+
+## Dry-Run Checklist (night before)
+- Tests green.
+- Vector index exists.
+- `/healthz` ready.
+- Morning Brief shows items.
+- One Assess → Plan → Act round trip.
+- Audit log present.
+- Extension sidebar works.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ Enable `Strict-Transport-Security` by setting `ENABLE_HSTS=true` **only** when s
 Payload and rate limits are configurable via environment variables such as
 `MAX_PAYLOAD_BYTES` and `RATE_LIMIT_RPS`. Metrics are exposed in Prometheus
 format at `/metrics` and include request counts, latencies and rate-limit drops.
+
+## Demo
+
+For a step-by-step walkthrough, see [DEMO_RUNBOOK.md](./DEMO_RUNBOOK.md).  
+To reset the environment:  
+```bash
+./scripts/reset_demo.sh
+```

--- a/scripts/reset_demo.sh
+++ b/scripts/reset_demo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rm -rf ./var/vector
+rm -rf ./var/audit
+
+python - <<'PY'
+from packages.backend.rag.indexer import build_index
+build_index("packages/backend/data/policies", "./var/vector")
+print("OK: vector index rebuilt")
+PY
+
+echo "OK: audit dir will be recreated on first /v1/act"


### PR DESCRIPTION
## Summary
- add reset_demo.sh to rebuild vector index
- document end-to-end demo in DEMO_RUNBOOK.md
- link runbook and reset script from README

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Promise/JSX type errors)*
- `npm test` *(fails: vitest cannot be imported in CommonJS modules)*
- `./scripts/reset_demo.sh` *(fails: ModuleNotFoundError: numpy; `pip install numpy faiss-cpu` blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1220f85883229b7f5f5b3ba05fde